### PR TITLE
update nuget System.IdentityModel.Tokens.Jwt to current major version

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -127,7 +127,9 @@ Task("Pack")
             new NuSpecDependency { Id = "Newtonsoft.Json", Version = "12.0.1" },
             new NuSpecDependency { Id = "Newtonsoft.Json.Bson", Version = "1.0.2" },
             new NuSpecDependency { Id = "IdentityModel", Version = "1.13.0" },
-            new NuSpecDependency { Id = "System.IdentityModel.Tokens.Jwt", Version = "4.0.3.308261200" },
+            new NuSpecDependency { Id = "Microsoft.IdentityModel.Logging", Version = "5.2.1" },
+            new NuSpecDependency { Id = "Microsoft.IdentityModel.Tokens", Version = "5.2.1" },
+            new NuSpecDependency { Id = "System.IdentityModel.Tokens.Jwt", Version = "5.2.1" },
             new NuSpecDependency { Id = "JetBrains.Annotations", Version = "2018.2.1" }
         },
         BasePath                 = buildDir,

--- a/src/Api.csproj
+++ b/src/Api.csproj
@@ -56,6 +56,13 @@
     <Reference Include="JetBrains.Annotations, Version=2018.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
       <HintPath>packages\JetBrains.Annotations.2018.2.1\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.IdentityModel.Logging.5.2.1\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.IdentityModel.Tokens.5.2.1\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -65,13 +72,14 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=4.0.30826.1200, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\System.IdentityModel.Tokens.Jwt.4.0.3.308261200\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>packages\System.IdentityModel.Tokens.Jwt.5.2.1\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />

--- a/src/Api.csproj
+++ b/src/Api.csproj
@@ -275,9 +275,7 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/Common/Utilities/OAuthHelper.cs
+++ b/src/Common/Utilities/OAuthHelper.cs
@@ -16,7 +16,7 @@ namespace Zeiss.IMT.PiWeb.Api.Common.Utilities
 
 	using System;
 	using System.Collections.Generic;
-	using System.IdentityModel.Tokens;
+	using System.IdentityModel.Tokens.Jwt;
 	using System.IO;
 	using System.Linq;
 	using System.Security.Claims;

--- a/src/app.config
+++ b/src/app.config
@@ -1,11 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>

--- a/src/packages.config
+++ b/src/packages.config
@@ -2,7 +2,9 @@
 <packages>
   <package id="IdentityModel" version="1.13.0" targetFramework="net45" />
   <package id="JetBrains.Annotations" version="2018.2.1" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.2.1" targetFramework="net472" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.2.1" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net45" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="4.0.3.308261200" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.1" targetFramework="net472" />
 </packages>

--- a/src/packages.config
+++ b/src/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IdentityModel" version="1.13.0" targetFramework="net45" />
-  <package id="JetBrains.Annotations" version="2018.2.1" targetFramework="net45" />
+  <package id="IdentityModel" version="1.13.0" targetFramework="net472" />
+  <package id="JetBrains.Annotations" version="2018.2.1" targetFramework="net472" />
   <package id="Microsoft.IdentityModel.Logging" version="5.2.1" targetFramework="net472" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.2.1" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net472" />
+  <package id="Newtonsoft.Json.Bson" version="1.0.2" targetFramework="net472" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.2.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
System.IdentityModel.Tokens.Jwt 5.x is not binary compatible with System.IdentityModel.Tokens.Jwt 4.x. Therefore any projekt that has already updated this very nuget for other reasons cannot consume PiWeb API SDK anymore.