### PR TITLE
PIWEB-2881: Add archive lookup for archives saved as raw data

### DIFF
--- a/src/Api.Definitions/Api.Definitions.csproj
+++ b/src/Api.Definitions/Api.Definitions.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Zeiss.PiWeb.Api.Definitions</RootNamespace>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageVersion>6.1.0-alpha0001</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly information">

--- a/src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
+++ b/src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Zeiss.PiWeb.Api.Rest.Dtos</RootNamespace>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageVersion>6.1.0-alpha0001</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly information">

--- a/src/Api.Rest.Dtos/RawData/RawDataArchiveBulkQueryDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataArchiveBulkQueryDto.cs
@@ -13,6 +13,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 	#region usings
 
 	using System;
+	using JetBrains.Annotations;
 	using Newtonsoft.Json;
 
 	#endregion
@@ -29,9 +30,9 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 		/// Constructor
 		/// </summary>
 		/// <param name="selectors"></param>
-		public RawDataArchiveBulkQueryDto( RawDataArchiveSelectorDto[] selectors )
+		public RawDataArchiveBulkQueryDto( [NotNull] RawDataArchiveSelectorDto[] selectors )
 		{
-			Selectors = selectors;
+			Selectors = selectors ?? throw new ArgumentNullException( nameof(selectors) );
 		}
 
 		/// <summary>

--- a/src/Api.Rest.Dtos/RawData/RawDataArchiveBulkQueryDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataArchiveBulkQueryDto.cs
@@ -1,0 +1,54 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2020                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
+{
+	#region usings
+
+	using System;
+	using Newtonsoft.Json;
+
+	#endregion
+
+	/// <summary>
+	/// Can query a set of specific archives saved as raw data.
+	/// </summary>
+	[Serializable]
+	public class RawDataArchiveBulkQueryDto
+	{
+		#region constructors
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="selectors"></param>
+		public RawDataArchiveBulkQueryDto( RawDataArchiveSelectorDto[] selectors )
+		{
+			Selectors = selectors;
+		}
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public RawDataArchiveBulkQueryDto() { }
+
+		#endregion
+
+		#region properties
+
+		/// <summary>
+		/// Selectors containing information about target, key and requested files of specified archives.
+		/// </summary>
+		[JsonProperty( "selectors" )]
+		public RawDataArchiveSelectorDto[] Selectors { get; set; } = { };
+
+		#endregion
+	}
+}

--- a/src/Api.Rest.Dtos/RawData/RawDataArchiveContentDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataArchiveContentDto.cs
@@ -1,0 +1,75 @@
+﻿#region Copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2020                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
+{
+	#region usings
+
+	using System;
+	using Newtonsoft.Json;
+
+	#endregion
+
+	/// <summary>
+	/// Represents a file which is part of an archive, containing actual data and meta information.
+	/// </summary>
+	[Serializable]
+	public class RawDataArchiveContentDto
+	{
+		#region constructors
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public RawDataArchiveContentDto() { }
+
+		#endregion
+
+		#region properties
+
+		/// <summary>
+		/// Full name of the file.
+		/// </summary>
+		[JsonProperty( "fileName" )]
+		public string FileName { get; set; }
+
+		/// <summary>
+		/// Length of data.
+		/// </summary>
+		[JsonProperty( "length" )]
+		public long Length { get; set; }
+
+		/// <summary>
+		/// Actual data representing the file.
+		/// </summary>
+		[JsonProperty( "data" )]
+		public byte[] Data { get; set; }
+
+		/// <summary>
+		/// MD% checksum of data.
+		/// </summary>
+		[JsonProperty( "md5" )]
+		public Guid MD5 { get; set; }
+
+		/// <summary>
+		/// <see cref="RawDataTargetEntityDto"/> of raw data.
+		/// </summary>
+		[JsonProperty( "target" )]
+		public RawDataTargetEntityDto Target { get; set; }
+
+		/// <summary>
+		/// Key to specify raw data of target entity.
+		/// </summary>
+		[JsonProperty( "key" )]
+		public int Key { get; set; }
+
+		#endregion
+	}
+}

--- a/src/Api.Rest.Dtos/RawData/RawDataArchiveContentDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataArchiveContentDto.cs
@@ -43,8 +43,8 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 		/// <summary>
 		/// Length of data.
 		/// </summary>
-		[JsonProperty( "length" )]
-		public long Length { get; set; }
+		[JsonProperty( "size" )]
+		public int Size { get; set; }
 
 		/// <summary>
 		/// Actual data representing the file.
@@ -53,22 +53,16 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 		public byte[] Data { get; set; }
 
 		/// <summary>
-		/// MD% checksum of data.
+		/// MD5 checksum of data.
 		/// </summary>
 		[JsonProperty( "md5" )]
 		public Guid MD5 { get; set; }
 
 		/// <summary>
-		/// <see cref="RawDataTargetEntityDto"/> of raw data.
+		/// <see cref="RawDataInformationDto"/> of original archive.
 		/// </summary>
-		[JsonProperty( "target" )]
-		public RawDataTargetEntityDto Target { get; set; }
-
-		/// <summary>
-		/// Key to specify raw data of target entity.
-		/// </summary>
-		[JsonProperty( "key" )]
-		public int Key { get; set; }
+		[JsonProperty( "archiveInfo" )]
+		public RawDataInformationDto ArchiveInfo { get; set; }
 
 		#endregion
 	}

--- a/src/Api.Rest.Dtos/RawData/RawDataArchiveEntriesDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataArchiveEntriesDto.cs
@@ -13,7 +13,6 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 	#region usings
 
 	using System;
-	using System.Collections.Generic;
 	using Newtonsoft.Json;
 
 	#endregion
@@ -23,36 +22,30 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 	/// as well as information about original archive (raw data).
 	/// </summary>
 	[Serializable]
-	public class RawDataArchiveIndexDto
+	public class RawDataArchiveEntriesDto
 	{
 		#region constructors
 
 		/// <summary>
 		/// Constructor
 		/// </summary>
-		public RawDataArchiveIndexDto() { }
+		public RawDataArchiveEntriesDto() { }
 
 		#endregion
 
 		#region properties
 
 		/// <summary>
-		/// <see cref="RawDataTargetEntityDto"/> of raw data.
+		/// <see cref="RawDataInformationDto"/> of original archive.
 		/// </summary>
-		[JsonProperty( "target" )]
-		public RawDataTargetEntityDto Target { get; set; }
-
-		/// <summary>
-		/// Key to specify raw data of target entity.
-		/// </summary>
-		[JsonProperty( "key" )]
-		public int Key { get; set; }
+		[JsonProperty( "archiveInfo" )]
+		public RawDataInformationDto ArchiveInfo { get; set; }
 
 		/// <summary>
 		/// List of files in specified archive.
 		/// </summary>
-		[JsonProperty( "files" )]
-		public IEnumerable<string> Files { get; set; }
+		[JsonProperty( "entries" )]
+		public string[] Entries { get; set; }
 
 		#endregion
 	}

--- a/src/Api.Rest.Dtos/RawData/RawDataArchiveIndexDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataArchiveIndexDto.cs
@@ -6,7 +6,7 @@
 /* (c) Carl Zeiss 2020                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#endregion﻿
+#endregion
 
 namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 {

--- a/src/Api.Rest.Dtos/RawData/RawDataArchiveIndexDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataArchiveIndexDto.cs
@@ -1,0 +1,59 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2020                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion﻿
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
+{
+	#region usings
+
+	using System;
+	using System.Collections.Generic;
+	using Newtonsoft.Json;
+
+	#endregion
+
+	/// <summary>
+	/// Contains list of entries which are part of an archive,
+	/// as well as information about original archive (raw data).
+	/// </summary>
+	[Serializable]
+	public class RawDataArchiveIndexDto
+	{
+		#region constructors
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public RawDataArchiveIndexDto() { }
+
+		#endregion
+
+		#region properties
+
+		/// <summary>
+		/// <see cref="RawDataTargetEntityDto"/> of raw data.
+		/// </summary>
+		[JsonProperty( "target" )]
+		public RawDataTargetEntityDto Target { get; set; }
+
+		/// <summary>
+		/// Key to specify raw data of target entity.
+		/// </summary>
+		[JsonProperty( "key" )]
+		public int Key { get; set; }
+
+		/// <summary>
+		/// List of files in specified archive.
+		/// </summary>
+		[JsonProperty( "files" )]
+		public IEnumerable<string> Files { get; set; }
+
+		#endregion
+	}
+}

--- a/src/Api.Rest.Dtos/RawData/RawDataArchiveSelectorDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataArchiveSelectorDto.cs
@@ -12,13 +12,15 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 {
 	#region usings
 
+	using System;
 	using System.Collections.Generic;
+	using JetBrains.Annotations;
 	using Newtonsoft.Json;
 
 	#endregion
 
 	/// <summary>
-	/// Selects a specific raw data entry which is an archive, as well as requested files of this archive.
+	/// Selects a number of entries of an archive saved as raw data object.
 	/// </summary>
 	public class RawDataArchiveSelectorDto
 	{
@@ -32,11 +34,11 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 		/// <summary>
 		/// Constructor
 		/// </summary>
-		public RawDataArchiveSelectorDto( int key, RawDataTargetEntityDto target, IEnumerable<string> files )
+		public RawDataArchiveSelectorDto( int key, [NotNull] RawDataTargetEntityDto target, [NotNull] string[] entries )
 		{
-			Files = files;
+			Entries = entries ?? throw new ArgumentNullException( nameof(entries) );
 			Key = key;
-			Target = target;
+			Target = target ?? throw new ArgumentNullException( nameof(target) );
 		}
 
 		#endregion
@@ -58,8 +60,8 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 		/// <summary>
 		/// List of requested files in specified archive.
 		/// </summary>
-		[JsonProperty( "files" )]
-		public IEnumerable<string> Files { get; set; }
+		[JsonProperty( "entries" )]
+		public string[] Entries { get; set; }
 
 		#endregion
 	}

--- a/src/Api.Rest.Dtos/RawData/RawDataArchiveSelectorDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataArchiveSelectorDto.cs
@@ -6,7 +6,7 @@
 /* (c) Carl Zeiss 2020                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#endregion﻿
+#endregion
 
 namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 {

--- a/src/Api.Rest.Dtos/RawData/RawDataArchiveSelectorDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataArchiveSelectorDto.cs
@@ -1,0 +1,66 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2020                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion﻿
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
+{
+	#region usings
+
+	using System.Collections.Generic;
+	using Newtonsoft.Json;
+
+	#endregion
+
+	/// <summary>
+	/// Selects a specific raw data entry which is an archive, as well as requested files of this archive.
+	/// </summary>
+	public class RawDataArchiveSelectorDto
+	{
+		#region constructors
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public RawDataArchiveSelectorDto() { }
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public RawDataArchiveSelectorDto( int key, RawDataTargetEntityDto target, IEnumerable<string> files )
+		{
+			Files = files;
+			Key = key;
+			Target = target;
+		}
+
+		#endregion
+
+		#region properties
+
+		/// <summary>
+		/// <see cref="RawDataTargetEntityDto"/> of raw data.
+		/// </summary>
+		[JsonProperty( "target" )]
+		public RawDataTargetEntityDto Target { get; set; }
+
+		/// <summary>
+		/// Key to specify raw data of target entity.
+		/// </summary>
+		[JsonProperty( "key" )]
+		public int Key { get; set; }
+
+		/// <summary>
+		/// List of requested files in specified archive.
+		/// </summary>
+		[JsonProperty( "files" )]
+		public IEnumerable<string> Files { get; set; }
+
+		#endregion
+	}
+}

--- a/src/Api.Rest.Dtos/RawData/RawDataBulkQueryDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataBulkQueryDto.cs
@@ -13,6 +13,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 	#region usings
 
 	using System;
+	using JetBrains.Annotations;
 	using Newtonsoft.Json;
 
 	#endregion
@@ -35,9 +36,9 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 		/// Constructor
 		/// </summary>
 		/// <param name="selectors"></param>
-		public RawDataBulkQueryDto( RawDataSelectorDto[] selectors )
+		public RawDataBulkQueryDto( [NotNull] RawDataSelectorDto[] selectors )
 		{
-			Selectors = selectors;
+			Selectors = selectors ?? throw new ArgumentNullException( nameof( selectors ) );
 		}
 
 		#endregion

--- a/src/Api.Rest.Dtos/RawData/RawDataBulkQueryDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataBulkQueryDto.cs
@@ -1,0 +1,55 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2015                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
+{
+	#region usings
+
+	using System;
+	using Newtonsoft.Json;
+
+	#endregion
+
+	/// <summary>
+	/// Can query a set of specific raw data entries in one go.
+	/// </summary>
+	[Serializable]
+	public class RawDataBulkQueryDto
+	{
+		#region constructors
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public RawDataBulkQueryDto()
+		{ }
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="selectors"></param>
+		public RawDataBulkQueryDto( RawDataSelectorDto[] selectors )
+		{
+			Selectors = selectors;
+		}
+
+		#endregion
+
+		#region properties
+
+		/// <summary>
+		/// Selectors containing information about target and key of requested archives.
+		/// </summary>
+		[JsonProperty( "selectors" )]
+		public RawDataSelectorDto[] Selectors { get; set; } = { };
+
+		#endregion
+	}
+}

--- a/src/Api.Rest.Dtos/RawData/RawDataSelectorDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataSelectorDto.cs
@@ -13,6 +13,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 	#region usings
 
 	using System;
+	using JetBrains.Annotations;
 	using Newtonsoft.Json;
 
 	#endregion
@@ -34,10 +35,10 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
 		/// <summary>
 		/// Constructor
 		/// </summary>
-		public RawDataSelectorDto( int key, RawDataTargetEntityDto target )
+		public RawDataSelectorDto( int key, [NotNull] RawDataTargetEntityDto target )
 		{
 			Key = key;
-			Target = target;
+			Target = target ?? throw new ArgumentNullException( nameof( target ) );
 		}
 
 		#endregion

--- a/src/Api.Rest.Dtos/RawData/RawDataSelectorDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataSelectorDto.cs
@@ -1,0 +1,61 @@
+﻿#region Copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2017                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.RawData
+{
+	#region usings
+
+	using System;
+	using Newtonsoft.Json;
+
+	#endregion
+
+	/// <summary>
+	/// Selects a specific raw data entry on a target.
+	/// </summary>
+	[Serializable]
+	public class RawDataSelectorDto
+	{
+		#region constructors
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public RawDataSelectorDto()
+		{ }
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		public RawDataSelectorDto( int key, RawDataTargetEntityDto target )
+		{
+			Key = key;
+			Target = target;
+		}
+
+		#endregion
+
+		#region properties
+
+		/// <summary>
+		/// <see cref="RawDataTargetEntityDto"/> of raw data.
+		/// </summary>
+		[JsonProperty( "target" )]
+		public RawDataTargetEntityDto Target { get; set; }
+
+		/// <summary>
+		/// Key to specify raw data of target entity.
+		/// </summary>
+		[JsonProperty( "key" )]
+		public int Key { get; set; }
+
+		#endregion
+	}
+}

--- a/src/Api.Rest.Dtos/RawData/RawDataSelectorDto.cs
+++ b/src/Api.Rest.Dtos/RawData/RawDataSelectorDto.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright
+﻿#region copyright
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss IMT (IZfM Dresden)                   */

--- a/src/Api.Rest/Api.Rest.csproj
+++ b/src/Api.Rest/Api.Rest.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>Zeiss.PiWeb.Api.Rest</RootNamespace>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1;net48</TargetFrameworks>
     <LangVersion>latest</LangVersion>
+    <PackageVersion>6.1.0-alpha0001</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly information">

--- a/src/Api.Rest/Contracts/IRawDataServiceRestClientBase.cs
+++ b/src/Api.Rest/Contracts/IRawDataServiceRestClientBase.cs
@@ -82,7 +82,7 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		/// <param name="targetEntity">The <see cref="RawDataTargetEntityDto"/> that specifies the archive</param>
 		/// <param name="targetKey">The unique key that identifies the raw data object for the specified target.</param>
 		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-		Task<RawDataArchiveIndexDto> GetRawDataArchiveEntries( RawDataTargetEntityDto targetEntity, int targetKey, CancellationToken cancellationToken = default );
+		Task<RawDataArchiveEntriesDto> ListRawDataArchiveEntries( RawDataTargetEntityDto targetEntity, int targetKey, CancellationToken cancellationToken = default );
 
 		/// <summary>
 		/// Fetches multiple lists of entries for queried raw data objects if they are archives of known format.
@@ -90,7 +90,7 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		/// <param name="query"><see cref="RawDataBulkQueryDto"/> with selectors containing targets of requested archives.</param>
 		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
 		/// <returns></returns>
-		Task<IEnumerable<RawDataArchiveIndexDto>> RawDataArchiveEntryQuery( RawDataBulkQueryDto query, CancellationToken cancellationToken = default );
+		Task<RawDataArchiveEntriesDto[]> RawDataArchiveEntryQuery( RawDataBulkQueryDto query, CancellationToken cancellationToken = default );
 
 		/// <summary>
 		/// Fetches file as byte array of specified raw data if it is part of an archive of known format.
@@ -98,16 +98,16 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		/// <param name="targetEntity">The <see cref="RawDataTargetEntityDto"/> that specifies the archive</param>
 		/// <param name="targetKey">The unique key that identifies the raw data object for the specified target.</param>
 		/// <param name="fileName">The requested file.</param>
-		/// <param name="expectedMd5">The md5 check sum that is expected for the result object, used for caching.</param>
+		/// <param name="expectedArchiveMd5">The md5 check sum that is expected for the targeted archive. NOT the returned entry. Used for caching.</param>
 		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-		Task<byte[]> GetRawDataArchiveContent( RawDataTargetEntityDto targetEntity, int targetKey, string fileName, Guid? expectedMd5 = null, CancellationToken cancellationToken = default );
+		Task<byte[]> GetRawDataArchiveContent( RawDataTargetEntityDto targetEntity, int targetKey, string fileName, Guid? expectedArchiveMd5 = null, CancellationToken cancellationToken = default );
 
 		/// <summary>
 		/// Fetches multiple files of queried raw data objects if they are part of selected archives of known format.
 		/// </summary>
 		/// <param name="query"><see cref="RawDataArchiveBulkQueryDto"/> with selectors containing targets of requested archives as well as requested files.</param>
 		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-		Task<IEnumerable<RawDataArchiveContentDto>> RawDataArchiveContentQuery( RawDataArchiveBulkQueryDto query, CancellationToken cancellationToken = default );
+		Task<RawDataArchiveContentDto[]> RawDataArchiveContentQuery( RawDataArchiveBulkQueryDto query, CancellationToken cancellationToken = default );
 
 		/// <summary>
 		/// Creates a new raw data object <paramref name="data"/> for the element specified by <paramref name="info"/>.

--- a/src/Api.Rest/Contracts/IRawDataServiceRestClientBase.cs
+++ b/src/Api.Rest/Contracts/IRawDataServiceRestClientBase.cs
@@ -13,6 +13,7 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 	#region usings
 
 	using System;
+	using System.Collections.Generic;
 	using System.Threading;
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
@@ -74,6 +75,39 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		/// <returns>The preview image as byte array.</returns>
 		/// <param name="cancellationToken">A token to cancel the hronous operation.</param>
 		Task<byte[]> GetRawDataThumbnail( [NotNull] RawDataTargetEntityDto target, int rawDataKey, CancellationToken cancellationToken = default );
+
+		/// <summary>
+		/// Fetches a list of entries if specified raw data is an archive of known format.
+		/// </summary>
+		/// <param name="targetEntity">The <see cref="RawDataTargetEntityDto"/> that specifies the archive</param>
+		/// <param name="targetKey">The unique key that identifies the raw data object for the specified target.</param>
+		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+		Task<RawDataArchiveIndexDto> GetRawDataArchiveEntries( RawDataTargetEntityDto targetEntity, int targetKey, CancellationToken cancellationToken = default );
+
+		/// <summary>
+		/// Fetches multiple lists of entries for queried raw data objects if they are archives of known format.
+		/// </summary>
+		/// <param name="query"><see cref="RawDataBulkQueryDto"/> with selectors containing targets of requested archives.</param>
+		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+		/// <returns></returns>
+		Task<IEnumerable<RawDataArchiveIndexDto>> RawDataArchiveEntryQuery( RawDataBulkQueryDto query, CancellationToken cancellationToken = default );
+
+		/// <summary>
+		/// Fetches file as byte array of specified raw data if it is part of an archive of known format.
+		/// </summary>
+		/// <param name="targetEntity">The <see cref="RawDataTargetEntityDto"/> that specifies the archive</param>
+		/// <param name="targetKey">The unique key that identifies the raw data object for the specified target.</param>
+		/// <param name="fileName">The requested file.</param>
+		/// <param name="expectedMd5">The md5 check sum that is expected for the result object, used for caching.</param>
+		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+		Task<byte[]> GetRawDataArchiveContent( RawDataTargetEntityDto targetEntity, int targetKey, string fileName, Guid? expectedMd5 = null, CancellationToken cancellationToken = default );
+
+		/// <summary>
+		/// Fetches multiple files of queried raw data objects if they are part of selected archives of known format.
+		/// </summary>
+		/// <param name="query"><see cref="RawDataArchiveBulkQueryDto"/> with selectors containing targets of requested archives as well as requested files.</param>
+		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+		Task<IEnumerable<RawDataArchiveContentDto>> RawDataArchiveContentQuery( RawDataArchiveBulkQueryDto query, CancellationToken cancellationToken = default );
 
 		/// <summary>
 		/// Creates a new raw data object <paramref name="data"/> for the element specified by <paramref name="info"/>.

--- a/src/Api.Rest/Contracts/RawDataServiceFeatureMatrix.cs
+++ b/src/Api.Rest/Contracts/RawDataServiceFeatureMatrix.cs
@@ -39,7 +39,11 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		// If the server supports at least this minor version filtering is possible.
 		public static Version RawDataAttributeFilterMinVersion { get; } = new Version( SupportedMajorVersion, 2 );
 
+		public static Version RawDataArchiveLookupMinVersion { get; } = new Version( SupportedMajorVersion, 5 );
+
 		public bool SupportsRawDataAttributeFilter => CurrentInterfaceVersion >= RawDataAttributeFilterMinVersion;
+
+		public bool SupportsArchiveLookup => CurrentInterfaceVersion >= RawDataArchiveLookupMinVersion;
 
 		#endregion
 	}

--- a/src/Api.Rest/HttpClient/RawData/RawDataServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/RawData/RawDataServiceRestClient.cs
@@ -285,7 +285,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 		}
 
 		/// <inheritdoc />
-		public async Task<RawDataArchiveIndexDto> GetRawDataArchiveEntries( RawDataTargetEntityDto targetEntity, int targetKey, CancellationToken cancellationToken = default )
+		public async Task<RawDataArchiveEntriesDto> ListRawDataArchiveEntries( RawDataTargetEntityDto targetEntity, int targetKey, CancellationToken cancellationToken = default )
 		{
 			if( targetEntity == null ) throw new ArgumentNullException( nameof( targetEntity ) );
 
@@ -300,11 +300,11 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 
 			var requestPath = $"rawData/{targetEntity.Entity}/{targetEntity.Uuid}/{targetKey}/archiveEntries";
 
-			return ( await _RestClient.Request<IEnumerable<RawDataArchiveIndexDto>>( RequestBuilder.CreateGet( requestPath ), cancellationToken ) ).First();
+			return ( await _RestClient.Request<RawDataArchiveEntriesDto[]>( RequestBuilder.CreateGet( requestPath ), cancellationToken ) ).First();
 		}
 
 		/// <inheritdoc />
-		public async Task<byte[]> GetRawDataArchiveContent( RawDataTargetEntityDto targetEntity, int targetKey, string fileName, Guid? expectedMd5 = null, CancellationToken cancellationToken = default )
+		public async Task<byte[]> GetRawDataArchiveContent( RawDataTargetEntityDto targetEntity, int targetKey, string fileName, Guid? expectedArchiveMd5 = null, CancellationToken cancellationToken = default )
 		{
 			if( targetEntity == null ) throw new ArgumentNullException( nameof( targetEntity ) );
 			if( fileName == null ) throw new ArgumentNullException( nameof( fileName ) );
@@ -318,15 +318,15 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 					featureMatrix.CurrentInterfaceVersion );
 			}
 
-			var requestPath = expectedMd5.HasValue
-				? $"rawData/{targetEntity.Entity}/{targetEntity.Uuid}/{targetKey}/archiveContent/{fileName}?expectedMd5={expectedMd5}"
+			var requestPath = expectedArchiveMd5.HasValue
+				? $"rawData/{targetEntity.Entity}/{targetEntity.Uuid}/{targetKey}/archiveContent/{fileName}?expectedArchiveMd5={expectedArchiveMd5}"
 				: $"rawData/{targetEntity.Entity}/{targetEntity.Uuid}/{targetKey}/archiveContent/{fileName}";
 
 			return await _RestClient.RequestBytes( RequestBuilder.CreateGet( requestPath ), cancellationToken );
 		}
 
 		/// <inheritdoc />
-		public async Task<IEnumerable<RawDataArchiveIndexDto>> RawDataArchiveEntryQuery( RawDataBulkQueryDto query, CancellationToken cancellationToken = default )
+		public async Task<RawDataArchiveEntriesDto[]> RawDataArchiveEntryQuery( RawDataBulkQueryDto query, CancellationToken cancellationToken = default )
 		{
 			if( query == null ) throw new ArgumentNullException( nameof( query ) );
 
@@ -339,14 +339,14 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 					featureMatrix.CurrentInterfaceVersion );
 			}
 
-			return await _RestClient.Request<IEnumerable<RawDataArchiveIndexDto>>( RequestBuilder.CreatePost(
+			return await _RestClient.Request<RawDataArchiveEntriesDto[]>( RequestBuilder.CreatePost(
 					"rawData/archiveEntryQuery",
 					Payload.Create( query ) ),
 				cancellationToken );
 		}
 
 		/// <inheritdoc />
-		public async Task<IEnumerable<RawDataArchiveContentDto>> RawDataArchiveContentQuery( RawDataArchiveBulkQueryDto query, CancellationToken cancellationToken = default )
+		public async Task<RawDataArchiveContentDto[]> RawDataArchiveContentQuery( RawDataArchiveBulkQueryDto query, CancellationToken cancellationToken = default )
 		{
 			if( query == null ) throw new ArgumentNullException( nameof( query ) );
 
@@ -364,7 +364,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 					Payload.Create( query ) ),
 				cancellationToken );
 
-			return RestClientHelper.DeserializeBinaryObject<IEnumerable<RawDataArchiveContentDto>>( stream );
+			return RestClientHelper.DeserializeBinaryObject<RawDataArchiveContentDto[]>( stream );
 		}
 
 		/// <summary>


### PR DESCRIPTION
This PR adds methods for retrieving information about archive entries as well as requested files of specified archives. This functionality expects that specified raw data is an archive of known format, currently .zip files.

New methods in RawDataServiceRest:
GetRawDataArchiveEntries - get a list of entries of specified archive
GetRawDataArchiveContent - get specified file of archive as byte stream
RawDataArchiveEntryQuery - get multiple lists of entries for queried archives
RawDataArchiveContentQuery - get multiple files of queried archives in BSON format


