### PR TITLE
Parse OrderDTO extracted into a separate class

### DIFF
--- a/src/Api.Rest.Dtos.Tests/Api.Rest.Dtos.Tests.csproj
+++ b/src/Api.Rest.Dtos.Tests/Api.Rest.Dtos.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+        <RootNamespace>Zeiss.PiWeb.Api.Rest.Dtos.Tests</RootNamespace>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <LangVersion>8.0</LangVersion>
+        <AssemblyName>Zeiss.PiWeb.Api.Rest.Dtos.Tests</AssemblyName>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AutoFixture" Version="4.11.0" />
+        <PackageReference Include="FluentAssertions" Version="5.10.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+        <PackageReference Include="NUnit" Version="3.12.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.16.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Api.Rest.Dtos\Api.Rest.Dtos.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/Api.Rest.Dtos.Tests/Data/OrderDtoParserTests.cs
+++ b/src/Api.Rest.Dtos.Tests/Data/OrderDtoParserTests.cs
@@ -1,0 +1,65 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2020                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.Tests.Data
+{
+	#region usings
+
+	using System;
+	using NUnit.Framework;
+	using Zeiss.PiWeb.Api.Rest.Dtos.Data;
+
+	#endregion
+
+	[TestFixture]
+	public class OrderDtoParserTests
+	{
+		#region methods
+
+		[Test]
+		public void Parse_HappyPath_ReturnsOrderDto()
+		{
+			var result = OrderDtoParser.Parse( "4 asc", EntityDto.Measurement );
+
+			Assert.NotNull( result );
+			Assert.AreEqual( 4, result.Attribute );
+			Assert.AreEqual( OrderDirectionDto.Asc, result.Direction );
+			Assert.AreEqual( EntityDto.Measurement, result.Entity );
+		}
+
+		[Test]
+		public void Parse_InvalidDirection_ReturnsOrderDtoWithDefaultDirection()
+		{
+			var result = OrderDtoParser.Parse( "4 invalidDirection", EntityDto.Measurement );
+
+			Assert.AreEqual( OrderDirectionDto.Desc, result.Direction );
+		}
+
+		[Test]
+		public void Parse_StringIsNull_ExceptionThrown()
+		{
+			Assert.Throws<ArgumentNullException>( () => OrderDtoParser.Parse( null!, EntityDto.Measurement ) );
+		}
+
+		[Test]
+		public void Parse_StringIsEmpty_ExceptionThrown()
+		{
+			Assert.Throws<ArgumentNullException>( () => OrderDtoParser.Parse( "", EntityDto.Measurement ) );
+		}
+
+		[Test]
+		public void Parse_StringIsInvalid_ExceptionThrown()
+		{
+			Assert.Throws<FormatException>( () => OrderDtoParser.Parse( "no order string", EntityDto.Measurement ) );
+		}
+
+		#endregion
+	}
+}

--- a/src/Api.Rest.Dtos/Data/AbstractMeasurementFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/AbstractMeasurementFilterAttributesDto.cs
@@ -13,7 +13,6 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 	#region usings
 
 	using System;
-	using System.Globalization;
 	using System.Linq;
 
 	#endregion
@@ -120,16 +119,6 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 		internal static string OrderByToString( OrderDto[] order )
 		{
 			return string.Join( ",", order.Select( o => $"{o.Attribute} {o.Direction}" ) );
-		}
-
-		internal static OrderDto ParseOrderBy( string value )
-		{
-			var items = value.Split( ' ' );
-
-			var key = ushort.Parse( items[ 0 ], CultureInfo.InvariantCulture );
-			var direction = string.Equals( "asc", items[ 1 ], StringComparison.OrdinalIgnoreCase ) ? OrderDirectionDto.Asc : OrderDirectionDto.Desc;
-
-			return new OrderDto( key, direction, EntityDto.Measurement );
 		}
 
 		#endregion

--- a/src/Api.Rest.Dtos/Data/DistinctMeasurementFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/DistinctMeasurementFilterAttributesDto.cs
@@ -88,7 +88,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 							result.LimitResult = int.Parse( value, CultureInfo.InvariantCulture );
 							break;
 						case OrderByParamName:
-							result.OrderBy = value.Split( ',' ).Select( ParseOrderBy ).ToArray();
+							result.OrderBy = value.Split( ',' ).Select( element => OrderDtoParser.Parse( element, EntityDto.Measurement ) ).ToArray();
 							break;
 						case SearchConditionParamName:
 							result.SearchCondition = SearchConditionParser.Parse( value );

--- a/src/Api.Rest.Dtos/Data/MeasurementFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/MeasurementFilterAttributesDto.cs
@@ -153,7 +153,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 							result.RequestedMeasurementAttributes = new AttributeSelector( RestClientHelper.ConvertStringToUInt16List( value ) );
 							break;
 						case OrderByParamName:
-							result.OrderBy = value.Split( ',' ).Select( ParseOrderBy ).ToArray();
+							result.OrderBy = value.Split( ',' ).Select( element => OrderDtoParser.Parse( element, EntityDto.Measurement ) ).ToArray();
 							break;
 						case SearchConditionParamName:
 							result.SearchCondition = SearchConditionParser.Parse( value );

--- a/src/Api.Rest.Dtos/Data/MeasurementValueFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/MeasurementValueFilterAttributesDto.cs
@@ -168,7 +168,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 							result.RequestedMeasurementAttributes = new AttributeSelector( RestClientHelper.ConvertStringToUInt16List( value ) );
 							break;
 						case OrderByParamName:
-							result.OrderBy = value.Split( ',' ).Select( ParseOrderBy ).ToArray();
+							result.OrderBy = value.Split( ',' ).Select( element => OrderDtoParser.Parse( element, EntityDto.Measurement ) ).ToArray();
 							break;
 						case SearchConditionParamName:
 							result.SearchCondition = SearchConditionParser.Parse( value );

--- a/src/Api.Rest.Dtos/Data/OrderDtoParser.cs
+++ b/src/Api.Rest.Dtos/Data/OrderDtoParser.cs
@@ -1,0 +1,50 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2020                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
+{
+	#region usings
+
+	using System;
+	using System.Globalization;
+	using JetBrains.Annotations;
+
+	#endregion
+
+	/// <summary>
+	/// Parser class for an <see cref="OrderDto"/>.
+	/// </summary>
+	public static class OrderDtoParser
+	{
+		#region methods
+
+		/// <summary>
+		/// Parses the given value string into an <see cref="OrderDto"/>.
+		/// </summary>
+		/// <param name="value">The string to parse.</param>
+		/// <param name="entityType">The type of entity.</param>
+		/// <returns>An parsed <see cref="OrderDto"/>.</returns>
+		/// <example>4 desc</example>
+		/// <example>12 asc</example>
+		public static OrderDto Parse( [NotNull] string value, EntityDto entityType )
+		{
+			if( string.IsNullOrEmpty( value ) ) throw new ArgumentNullException( nameof( value ) );
+
+			var items = value.Split( ' ' );
+
+			var key = ushort.Parse( items[ 0 ], CultureInfo.InvariantCulture );
+			var direction = string.Equals( "asc", items[ 1 ], StringComparison.OrdinalIgnoreCase ) ? OrderDirectionDto.Asc : OrderDirectionDto.Desc;
+
+			return new OrderDto( key, direction, entityType );
+		}
+
+		#endregion
+	}
+}

--- a/src/Api.sln
+++ b/src/Api.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api.Definitions", "Api.Defi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api.Rest.Dtos", "Api.Rest.Dtos\Api.Rest.Dtos.csproj", "{008EE7B0-8795-4C7B-A3DE-46C02A571127}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api.Rest.Dtos.Tests", "Api.Rest.Dtos.Tests\Api.Rest.Dtos.Tests.csproj", "{3A6AFFB6-94AE-432D-968B-CC469587496F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{008EE7B0-8795-4C7B-A3DE-46C02A571127}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{008EE7B0-8795-4C7B-A3DE-46C02A571127}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{008EE7B0-8795-4C7B-A3DE-46C02A571127}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A6AFFB6-94AE-432D-968B-CC469587496F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A6AFFB6-94AE-432D-968B-CC469587496F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A6AFFB6-94AE-432D-968B-CC469587496F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A6AFFB6-94AE-432D-968B-CC469587496F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Within this PR, the method `AbstractMeasurementFilterAttributesDto.ParseOrderBy` was extracted into the separate class `OrderDtoParser`.
I also wrote some unit tests for the new class.