### PR TITLE
Fix: Correct notation (Camel Case) for query parameters related to measurements

### DIFF
--- a/src/Api.Rest.Dtos/Data/AbstractMeasurementFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/AbstractMeasurementFilterAttributesDto.cs
@@ -21,15 +21,15 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 	{
 		#region constants
 
-		public const string PartUuidsParamName = "partuuids";
+		public const string PartUuidsParamName = "partUuids";
 		protected const string DeepParamName = "deep";
-		protected const string LimitResultParamName = "limitresult";
+		protected const string LimitResultParamName = "limitResult";
 		protected const string OrderByParamName = "order";
-		public const string MeasurementUuidsParamName = "measurementuuids";
-		protected const string SearchConditionParamName = "searchcondition";
+		public const string MeasurementUuidsParamName = "measurementUuids";
+		protected const string SearchConditionParamName = "searchCondition";
 		protected const string AggregationParamName = "aggregation";
-		protected const string FromModificationDateParamName = "frommodificationdate";
-		protected const string ToModificationDateParamName = "tomodificationdate";
+		protected const string FromModificationDateParamName = "fromModificationDate";
+		protected const string ToModificationDateParamName = "toModificationDate";
 
 		#endregion
 

--- a/src/Api.Rest.Dtos/Data/MeasurementValueFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/MeasurementValueFilterAttributesDto.cs
@@ -28,13 +28,13 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 	{
 		#region constants
 
-		private const string RequestedValueAttributesParamName = "requestedvalueattributes";
-		private const string RequestedMeasurementAttributesParamName = "requestedmeasurementattributes";
-		public const string CharacteristicsUuidListParamName = "characteristicuuids";
+		private const string RequestedValueAttributesParamName = "requestedValueAttributes";
+		private const string RequestedMeasurementAttributesParamName = "requestedMeasurementAttributes";
+		public const string CharacteristicsUuidListParamName = "characteristicUuids";
 
-		private const string MergeAttributesParamName = "mergeattributes";
-		private const string MergeConditionParamName = "mergecondition";
-		private const string MergeMasterPartParamName = "mergemasterpart";
+		private const string MergeAttributesParamName = "mergeAttributes";
+		private const string MergeConditionParamName = "mergeCondition";
+		private const string MergeMasterPartParamName = "mergeMasterPart";
 
 		#endregion
 


### PR DESCRIPTION
The query parameters where validated against the current PiWeb swagger documentation