### PR TITLE
docs: fixed sdk examples

### DIFF
--- a/_pages/SDK/v6.0/021-general.md
+++ b/_pages/SDK/v6.0/021-general.md
@@ -2,7 +2,7 @@
 
 The .NET SDK is suitable for all .NET languages. You can include it to your project either by
 
-- including the dll by using our [nuget package](https://www.nuget.org/packages/Zeiss.IMT.PiWebApi.Client/) (recommended)
+- including the dll by using our [nuget package](https://www.nuget.org/packages/Zeiss.PiWeb.Api.Rest/) (recommended)
 - using the source files from our [GitHub repository](https://github.com/ZEISS-PiWeb/PiWeb-Api).
 
 >{{ site.headers['bestPractice'] }} Use our sample application for better understanding

--- a/_pages/SDK/v6.0/022-basics/0221-basics-configuration.md
+++ b/_pages/SDK/v6.0/022-basics/0221-basics-configuration.md
@@ -83,7 +83,7 @@ Here we create an attribute *Description*, which can be used in parts, catalogs 
 
 {% highlight csharp %}
 //Create a catalog using recently created attributeDef as catalog's valid attribute
-Catalog testCatalog = new CatalogDto
+var testCatalog = new CatalogDto
 {
   Name = "TestCatalog",
   Uuid = Guid.NewGuid(),
@@ -109,8 +109,7 @@ Keys are unique, so creating an attribute with the same key will result in an ex
 
 {% highlight csharp %}
 //Create the client and fetch the configuration
-var client = new DataServiceRestClient( new Uri("https://piwebserver:8080") );
-var configuration = await client.GetConfiguration();
+var configuration = await DataServiceClient.GetConfiguration();
 
 //Create a new AttributeDefinitionDto with key 11001
 var attributeDefinition = new AttributeDefinitionDto( 11001, "Description", AttributeTypeDto.AlphaNumeric, 255 );
@@ -119,8 +118,8 @@ var attributeDefinition = new AttributeDefinitionDto( 11001, "Description", Attr
 var attributeDoesAlreadyExist = configuration.GetDefinition( 11001 );
 
 //Create new attribute if not existing
-if(attributeDoesAlreadyExist != null)
+if(attributeDoesAlreadyExist == null)
 {
-  await client.CreateAttributeDefinition( EntityDto.Part, attributeDefinition );
+  await DataServiceClient.CreateAttributeDefinition( EntityDto.Part, attributeDefinition );
 }
 {% endhighlight %}

--- a/_pages/SDK/v6.0/022-basics/0222-basics-inspectionplan.md
+++ b/_pages/SDK/v6.0/022-basics/0222-basics-inspectionplan.md
@@ -118,6 +118,27 @@ await DataServiceClient.CreateParts( new[] { parentPart, childPart } );
 {% endhighlight %}
 The name of the part is specified within its path. Nesting is easy as you just create the path and structure according to your desired hierarchy. Remember again that characteristics cannot contain parts.
 
+>{{ site.headers['bestPractice'] }} Create or update multiple entities in a single call
+To achieve a good performance, it is highly recommended to create or update items in a single call. That is why all create and update methods expect an array parameter.
+
+{{ site.headers['example'] }} Creating characteristics for the part "MetalPart"
+
+{% highlight csharp %}
+//Create characteristics for MetalPart
+var char1Path = PathHelper.RoundtripString2PathInformation( "PC:/MetalPart/Char1/" );
+var char2Path = PathHelper.RoundtripString2PathInformation( "PC:/MetalPart/Char2/" );
+//Create characteristic for SubPart
+var char3Path = PathHelper.RoundtripString2PathInformation( "PPC:/MetalPart/SubPart/Char3/" );
+
+//Create InspectionPlanCharacteristicDto objects
+var char1 = new InspectionPlanCharacteristicDto { Path = char1Path, Uuid = Guid.NewGuid() };
+var char2 = new InspectionPlanCharacteristicDto { Path = char2Path, Uuid = Guid.NewGuid() };
+var char3 = new InspectionPlanCharacteristicDto { Path = char3Path, Uuid = Guid.NewGuid() };
+
+//Use Client to create characteristics on server
+await DataServiceClient.CreateCharacteristics( new[] {char1, char2, char3} );
+{% endhighlight %}
+
 {{ site.headers['example'] }} Fetching different entities
 
 {% highlight csharp %}
@@ -135,28 +156,6 @@ You can fetch different entities with the corresponding method. The path specifi
 >{{ site.headers['knownLimitation'] }} Missing filter possibilities
 Not all endpoints provide extensive filter possibilities, as it is much more performant to filter on client side. This reduces additional workload for the server.
 
->{{ site.headers['bestPractice'] }} Create or update multiple entities in a single call
-To achieve a good performance, it is highly recommended to create or update items in a single call. That is why all create and update methods expect an array parameter.
-
-{{ site.headers['example'] }} Creating characteristics for the part "MetalPart"
-
-{% highlight csharp %}
-//Create characteristics for MetalPart
-var charPath1 = PathHelper.RoundtripString2PathInformation( "PC:/MetalPart/Char1/" );
-var charPath2 = PathHelper.RoundtripString2PathInformation( "PC:/MetalPart/Char2/" );
-//Create characteristic for SubPart
-var charPath3 = PathHelper.RoundtripString2PathInformation( "PPC:/MetalPart/SubPart/Char3/" );
-
-//Create InspectionPlanCharacteristicDto objects
-var char1 = new InspectionPlanCharacteristicDto { Path = char1Path, Uuid = Guid.NewGuid() };
-var char2 = new InspectionPlanCharacteristicDto { Path = char2Path, Uuid = Guid.NewGuid() };
-var char3 = new InspectionPlanCharacteristicDto { Path = char3Path, Uuid = Guid.NewGuid() };
-
-//Use Client to create characteristics on server
-await DataServiceClient.CreateCharacteristics( new[] {char1, char2, char3} );
-{% endhighlight %}
-
-<br>
 {{ site.headers['example'] }} Deleting "MetalPart"
 
 {% highlight csharp %}
@@ -164,12 +163,12 @@ await DataServiceClient.CreateCharacteristics( new[] {char1, char2, char3} );
 var partPath = PathHelper.String2PartPathInformation("/MetalPart/");
 
 //Get the part from server, depth 0 to only get the exact part and no children
-var parts = await dataServiceClient.GetParts(partPath, depth:0);
+var parts = await DataServiceClient.GetParts(partPath, depth:0);
 //Get the part from the returned array (first entry in our case)
 var metalPart = parts.First();
 
 //Delete the part by its Uuid
-await dataServiceClient.DeleteParts(new[] {parts.Uuid});
+await DataServiceClient.DeleteParts(new[] { metalPart.Uuid });
 {% endhighlight %}
 
 >{{ site.images['info'] }} Deleting a part also deletes its subparts, characteristics and measurements. This is only possible if the server setting *"Parts with measurement data can be deleted"* is activated.

--- a/_pages/SDK/v6.0/022-basics/0223-basics-measurementsandvalues.md
+++ b/_pages/SDK/v6.0/022-basics/0223-basics-measurementsandvalues.md
@@ -110,7 +110,7 @@ In this example we fill the `Attributes` property of our `DataValueDto` object d
 //Create the attribute (remember to check if it already exists)
 var measurementAttributeDefinition = new AttributeDefinitionDto( WellKnownKeys.Measurement.InspectorName,
 "Inspector", AttributeTypeDto.AlphaNumeric, 30 );
-await client.CreateAttributeDefinition( EntityDto.Measurement, measurementAttributeDefinition );
+await DataServiceClient.CreateAttributeDefinition( EntityDto.Measurement, measurementAttributeDefinition );
 
 //Create the measurement
 var measurement = new DataMeasurementDto
@@ -127,7 +127,7 @@ var measurement = new DataMeasurementDto
 };
 
 //Create measurement on the server
-await DataServiceClient.CreateMeasurementValues( new[] { Measurement } );
+await DataServiceClient.CreateMeasurementValues( new[] { measurement } );
 {% endhighlight %}
 
 >{{ site.headers['bestPractice'] }} Use the property `Time`
@@ -143,13 +143,13 @@ Next to creating or updating measurements, another important functionality is fe
 {{ site.headers['example'] }} Fetching measurements of a part
 {% highlight csharp %}
 //Create PathInformation of the desired part that contains measurements
-var partPath = PathHelper.RoundtripString2PathInformation("P:/Measured part/"))
+var partPath = PathHelper.RoundtripString2PathInformation( "P:/Measured part/" );
 
 //Fetch all measurements of this part without measured values
-var fetchedMeasurements = await DataServiceClient.GetMeasurements( partPath )
+var fetchedMeasurements = await DataServiceClient.GetMeasurements( partPath );
 
 //Or fetch all measurements of this part with measured values
-var fetchedMeasurementsWithValues = await DataServiceClient.GetMeasurementValues( partPath )
+var fetchedMeasurementsWithValues = await DataServiceClient.GetMeasurementValues( partPath );
 {% endhighlight %}
 This is the simplest way to fetch measurements and the associated measured values as the unfiltered method returns all measurements of the specified part. Each measurement then contains a `DataCharacteristicDto` objects linking values to characteristics. Since this can result in a large collection of results you have the possibility to create a filter based on different criteria.
 This can be done by using `MeasurementFilterAttributesDto` which is derived from `AbstractMeasurementFilterAttributesDto`:
@@ -200,7 +200,7 @@ var fetchedMeasurements = await DataServiceClient.GetMeasurementValues(
     Deep = true,
     FromModificationDate = DateTime.Now - TimeSpan.FromDays(2),
     ToModificationDate = DateTime.Now
-  })
+  });
 {% endhighlight %}
 This returns the measurements of the last 48 hours. You can also use actual dates instead of a time range. It is not required to specify both dates, you could use `FromModificationDate` and `ToModificationDate` independently.
 
@@ -214,11 +214,11 @@ var fetchedMeasurements = await DataServiceClient.GetMeasurementValues(
     AggregationMeasurements = AggregationMeasurementSelectionDto.All,
     Deep = true,
     FromModificationDate = DateTime.Now - TimeSpan.FromDays(2),
-    ToModificationDate = DateTime.Now
-    RequestedMeasurementAttributes = new AttributeSelector(){ Attributes = new ushort[]{ WellKnownKeys.Measurement.Time, WellKnownKeys.Measurement.OperatorName, WellKnownKeys.Measurement.Conctract } }  
-  })
+    ToModificationDate = DateTime.Now,
+    RequestedMeasurementAttributes = new AttributeSelector(){ Attributes = new ushort[]{ WellKnownKeys.Measurement.Time, WellKnownKeys.Measurement.InspectorName, WellKnownKeys.Measurement.Contract } }
+  });
 {% endhighlight %}
-To retrieve only a subset of measurement attributes we set `RequestedMeasurementAttributes`, which requires an `AttributeSelector`. Simply add the keys of the desired attributes to the `Attributes` property, so in this case *time*, *operator name* and *contract* attributes. The property `RequestedValueAttributes` works the same way for measured value attributes.
+To retrieve only a subset of measurement attributes we set `RequestedMeasurementAttributes`, which requires an `AttributeSelector`. Simply add the keys of the desired attributes to the `Attributes` property, so in this case *time*, *inspector name* and *contract* attributes. The property `RequestedValueAttributes` works the same way for measured value attributes.
 
 >{{ site.images['info'] }} The measured value attribute `K1` is always returned in the `Value` property of a `DataCharacteristicDto`, even when not explicitly requested in `AttributeSelector`.
 
@@ -235,7 +235,7 @@ var fetchedMeasurements = await DataServiceClient.GetMeasurementValues(
       Operation = OperationDto.GreaterThan,
       Value = XmlConvert.ToString(DateTime.UtcNow - TimeSpan.FromDays(2), XmlDateTimeSerializationMode.Utc)
     }
-  })
+  });
 {% endhighlight %}
 In this case we use a `GenericSearchAttributeConditionDto`, a search condition for attributes. You specify the attribute key with the value of interest, an operation and the value you want to check against. This example again returns the measurements of the last 48 hours.
 To create more complex filters please use  `GenericSearchAndDto`, `GenericSearchOrDto` and/or `GenericSearchNotDto`. <br>

--- a/_pages/SDK/v6.0/022-basics/0224-basics-rawdata.md
+++ b/_pages/SDK/v6.0/022-basics/0224-basics-rawdata.md
@@ -108,7 +108,7 @@ sampleFile = Encoding.UTF8.GetBytes( "Important information changed!" );
 
 //Update RawDataInformation
 informationAboutSampleFile.MD5 = new Guid(MD5.Create().ComputeHash(sampleFile)); //recompute hash
-informationAboutSampleFile.length = sampleFile.length;
+informationAboutSampleFile.Size = sampleFile.Length;
 
 //Update file on server
 await RawDataServiceClient.UpdateRawData(informationAboutSampleFile, sampleFile);


### PR DESCRIPTION
- fixes for compilation: variable names, missing semicolons, brackets
- "client" was changed to "DataServiceClient", according to the other examples and the initial declaration
- two examples were swapped to create entities before fetching them