### PR TITLE
[PIWEB-13767] feat: Add async deletion of measurements

### DIFF
--- a/src/Api.Rest.Dtos/Data/OperationExecutionStatusDto.cs
+++ b/src/Api.Rest.Dtos/Data/OperationExecutionStatusDto.cs
@@ -1,0 +1,41 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2021                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
+{
+	#region usings
+
+	using Newtonsoft.Json;
+	using Newtonsoft.Json.Converters;
+
+	#endregion
+
+	/// <summary>
+	/// Possible execution statuses of a long running operation.
+	/// </summary>
+	[JsonConverter( typeof( StringEnumConverter ) )]
+	public enum OperationExecutionStatusDto
+	{
+		/// <summary>
+		/// Operation is currently running.
+		/// </summary>
+		Running,
+
+		/// <summary>
+		/// Operation has finished.
+		/// </summary>
+		Finished,
+
+		/// <summary>
+		/// Operation has finished with an exception.
+		/// </summary>
+		Exception
+	}
+}

--- a/src/Api.Rest.Dtos/Data/OperationStatusDto.cs
+++ b/src/Api.Rest.Dtos/Data/OperationStatusDto.cs
@@ -1,0 +1,45 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2021                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
+{
+	#region usings
+
+	using System;
+	using Newtonsoft.Json;
+
+	#endregion
+
+	/// <summary>
+	/// Contains information about the execution status of a long running operation.
+	/// </summary>
+	public class OperationStatusDto
+	{
+		#region properties
+
+		/// <summary>
+		/// Uuid to identify the operation.
+		/// </summary>
+		public Guid OperationUuid { get; set; }
+
+		/// <summary>
+		/// Status of execution, e.g. Running, Finished or Exception.
+		/// </summary>
+		public OperationExecutionStatusDto ExecutionStatus { get; set; }
+
+		/// <summary>
+		/// Thrown exception during execution, wrapped in an error object.
+		/// </summary>
+		[JsonProperty( NullValueHandling = NullValueHandling.Include )]
+		public Error Exception { get; set; }
+
+		#endregion
+	}
+}

--- a/src/Api.Rest/Contracts/DataServiceFeatureMatrix.cs
+++ b/src/Api.Rest/Contracts/DataServiceFeatureMatrix.cs
@@ -49,6 +49,9 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		//Clearing a part
 		public static readonly Version ClearPartMinVersion = new Version( SupportedMajorVersion, 5 );
 
+		//Request asynchronous deletion of measurements and check status with long polling.
+		public static readonly Version AsyncMeasurementDeletionMinVersion = new Version( SupportedMajorVersion, 7 );
+
 		#endregion
 
 		#region constructors
@@ -79,6 +82,8 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		public bool SupportRestrictMeasurementSearchByMergeMasterPart => CurrentInterfaceVersion >= RestrictMeasurementSearchByMergeMasterPartMinVersion;
 
 		public bool SupportClearPart => CurrentInterfaceVersion >= ClearPartMinVersion;
+
+		public bool SupportsAsyncMeasurementDeletion => CurrentInterfaceVersion >= AsyncMeasurementDeletionMinVersion;
 
 		#endregion
 	}

--- a/src/Api.Rest/Contracts/WrappedServerErrorException.cs
+++ b/src/Api.Rest/Contracts/WrappedServerErrorException.cs
@@ -80,6 +80,16 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 			}
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="WrappedServerErrorException" /> class.
+		/// </summary>
+		/// <param name="error">The server side error.</param>
+		public WrappedServerErrorException( Error error ) :
+			base( error?.Message ?? "Server error while processing the request." )
+		{
+			Error = error;
+		}
+
 		#endregion
 
 		#region properties


### PR DESCRIPTION
The DataService methods
- DeleteMeasurementsByUuid
- DeleteMeasurementsByPartUuids
- DeleteMeasurementsByPartPath

will automatically use an async pattern with polling if the server supports this feature.
This way the awaitable task is independent of the HTTP timeout.