### PR TITLE
Fix: Return first certificate for thumbrint search of certificates

### DIFF
--- a/src/Api.Rest/Common/Utilities/CertificateHelper.cs
+++ b/src/Api.Rest/Common/Utilities/CertificateHelper.cs
@@ -57,7 +57,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Utilities
 
 			var storeCerts = GetCertificatesFromStoreInternal( storeName, storeLocation ).Find( X509FindType.FindByThumbprint, thumbprint, onlyValidCertificates );
 
-			return storeCerts.Count == 1 ? storeCerts[ 0 ] : null;
+			return storeCerts.Count >= 1 ? storeCerts[ 0 ] : null;
 		}
 
 		private static X509Certificate2Collection GetCertificatesFromStoreInternal( StoreName storeName = StoreName.My, StoreLocation storeLocation = StoreLocation.CurrentUser )


### PR DESCRIPTION
If a certificate has a duplicate in the certificate store we simply return the first occurence. Thumbprint is unique for the secure hash functions currently used in certificate infrastructure, so the returned certificates are exactly the same.