### PR TITLE
Fix: LimitResult and OrderBy when splitting request

### DIFF
--- a/src/Api.Rest.Tests/HttpClient/Data/DataServiceRestClientTest.cs
+++ b/src/Api.Rest.Tests/HttpClient/Data/DataServiceRestClientTest.cs
@@ -1,0 +1,114 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2021                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Tests.HttpClient.Data
+{
+	#region usings
+
+	using System;
+	using System.Linq;
+	using System.Threading.Tasks;
+	using FluentAssertions;
+	using Newtonsoft.Json;
+	using NUnit.Framework;
+	using Zeiss.PiWeb.Api.Rest.Dtos.Data;
+	using Zeiss.PiWeb.Api.Rest.HttpClient.Data;
+
+	#endregion
+
+	[TestFixture]
+	public class DataServiceRestClientTest
+	{
+		#region constants
+
+		private const int Port = 8081;
+
+		#endregion
+
+		#region members
+
+		private static readonly Uri Uri = new Uri( $"http://localhost:{Port}/" );
+
+		#endregion
+
+		#region methods
+
+		[Test]
+		public async Task RequestSplit_OrderSpecified_OrderIsCorrect()
+		{
+			using var server = WebServer.StartNew( Port );
+			//maxUriLength of 80 leads request splitting per part uuid
+			using var client = new DataServiceRestClient( Uri, 80 );
+
+			//attribute 999 is our reference order which we expect in our result
+			var firstMeasurementSet = new[]
+			{
+				new SimpleMeasurementDto
+					{ Attributes = new[] { new AttributeDto( 5, 3 ), new AttributeDto( 55, 10 ), new AttributeDto( 999, 2 ) } },
+				new SimpleMeasurementDto
+					{ Attributes = new[] { new AttributeDto( 5, 1 ), new AttributeDto( 55, 99 ), new AttributeDto( 999, 0 ) } },
+				new SimpleMeasurementDto
+					{ Attributes = new[] { new AttributeDto( 5, 6 ), new AttributeDto( 55, 99 ), new AttributeDto( 999, 5 ) } }
+			};
+
+			var secondMeasurementSet = new[]
+			{
+				new SimpleMeasurementDto
+					{ Attributes = new[] { new AttributeDto( 5, 4 ), new AttributeDto( 55, 99 ), new AttributeDto( 999, 4 ) } },
+				new SimpleMeasurementDto
+					{ Attributes = new[] { new AttributeDto( 5, 2 ), new AttributeDto( 55, 99 ), new AttributeDto( 999, 1 ) } },
+				new SimpleMeasurementDto
+					{ Attributes = new[] { new AttributeDto( 5, 3 ), new AttributeDto( 55, 20 ), new AttributeDto( 999, 3 ) } }
+			};
+
+			server.RegisterReponse( "/DataServiceRest/measurements?partUuids=%7B11111111-1111-1111-1111-111111111111%7D&order=5%20Asc%2C55%20Asc", JsonConvert.SerializeObject( firstMeasurementSet ) );
+			server.RegisterReponse( "/DataServiceRest/measurements?partUuids=%7B22222222-2222-2222-2222-222222222222%7D&order=5%20Asc%2C55%20Asc", JsonConvert.SerializeObject( secondMeasurementSet ) );
+
+			var result = await client.GetMeasurements( filter: new MeasurementFilterAttributesDto
+			{
+				PartUuids = new[] { Guid.Parse( "11111111-1111-1111-1111-111111111111" ), Guid.Parse( "22222222-2222-2222-2222-222222222222" ) },
+				OrderBy = new[] { new OrderDto( 5, OrderDirectionDto.Asc, EntityDto.Measurement ), new OrderDto( 55, OrderDirectionDto.Asc, EntityDto.Measurement ) }
+			} );
+
+			//check that the order is correct according to our attribute 999
+			var index = 0;
+			foreach( var measurement in result )
+			{
+				measurement.Attributes.FirstOrDefault( a => a.Key == 999 )?.Value.Should().Be( index.ToString() );
+				index++;
+			}
+		}
+
+		[Test]
+		public async Task RequestSplit_LimitResultSpecified_LimitCorrect()
+		{
+			using var server = WebServer.StartNew( Port );
+			//maxUriLength of 80 leads request splitting per part uuid
+			using var client = new DataServiceRestClient( Uri, 80 );
+
+			var firstMeasurementSet = new[] { new SimpleMeasurementDto(), new SimpleMeasurementDto(), new SimpleMeasurementDto() };
+
+			var secondMeasurementSet = new[] { new SimpleMeasurementDto(), new SimpleMeasurementDto(), new SimpleMeasurementDto() };
+
+			server.RegisterReponse( "/DataServiceRest/measurements?partUuids=%7B11111111-1111-1111-1111-111111111111%7D&limitResult=5&order=4%20Desc", JsonConvert.SerializeObject( firstMeasurementSet ) );
+			server.RegisterReponse( "/DataServiceRest/measurements?partUuids=%7B22222222-2222-2222-2222-222222222222%7D&limitResult=5&order=4%20Desc", JsonConvert.SerializeObject( secondMeasurementSet ) );
+
+			var result = await client.GetMeasurements( filter: new MeasurementFilterAttributesDto
+			{
+				PartUuids = new[] { Guid.Parse( "11111111-1111-1111-1111-111111111111" ), Guid.Parse( "22222222-2222-2222-2222-222222222222" ) },
+				LimitResult = 5
+			} );
+
+			result.Length.Should().Be( 5 );
+		}
+
+		#endregion
+	}
+}

--- a/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
@@ -19,9 +19,9 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 	using System.Threading;
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
+	using Zeiss.PiWeb.Api.Definitions;
 	using Zeiss.PiWeb.Api.Rest.Common.Client;
 	using Zeiss.PiWeb.Api.Rest.Common.Data;
-	using Zeiss.PiWeb.Api.Rest.Common.Utilities;
 	using Zeiss.PiWeb.Api.Rest.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;
 	using Zeiss.PiWeb.Api.Rest.Dtos.Data;
@@ -99,6 +99,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 			var targetSize = RestClientHelper.GetUriTargetSize( ServiceLocation, requestRestriction, MaxUriLength );
 
 			var result = new List<DataMeasurementDto>( filter.MeasurementUuids.Length );
+			var resultSets = 0;
 			foreach( var uuids in ArrayHelper.Split( filter.MeasurementUuids, targetSize, RestClientHelper.LengthOfListElementInUri ) )
 			{
 				newFilter.MeasurementUuids = uuids;
@@ -110,9 +111,11 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 				{
 					result.AddRange( await _RestClient.Request<DataMeasurementDto[]>( RequestBuilder.CreateGet( "values", CreateParameterDefinitions( partPath, newFilter ).ToArray() ), cancellationToken ).ConfigureAwait( false ) );
 				}
+
+				resultSets++;
 			}
 
-			return result.ToArray();
+			return resultSets > 1 ? LimitAndSortResult( result, filter, resultSets ).Cast<DataMeasurementDto>().ToArray() : result.ToArray();
 		}
 
 		private async Task<DataMeasurementDto[]> GetMeasurementValuesSplitByCharacteristics( PathInformationDto partPath, MeasurementValueFilterAttributesDto filter, CancellationToken cancellationToken )
@@ -202,6 +205,70 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 			}
 
 			return _FeatureMatrix;
+		}
+
+		/// <summary>
+		/// Limit and sort received measurements if the initial request was split into multiple requests due to uri length.
+		/// </summary>
+		/// <param name="source">Fetched measurements</param>
+		/// <param name="filter">Set filter to check for LimitResult and OrderBy</param>
+		/// <param name="resultSets">Number of requests after splitting the initial request</param>
+		/// <returns>Array of measurements in correct order and size.</returns>
+		private static IEnumerable<SimpleMeasurementDto> LimitAndSortResult( IEnumerable<SimpleMeasurementDto> source, AbstractMeasurementFilterAttributesDto filter, int resultSets )
+		{
+			if( resultSets <= 1 ) return source;
+
+			if( filter.OrderBy == null || !filter.OrderBy.Any() )
+				return filter.LimitResult < 0 ? source : source.Take( filter.LimitResult );
+
+			var orderedResult = StartAttributeOrderChain( filter.OrderBy.First(), source );
+
+			//Evaluate each OrderBy
+			foreach( var orderDto in filter.OrderBy.Skip( 1 ) )
+			{
+				orderedResult = AppendAttributeOrderChain( orderDto, orderedResult );
+			}
+
+			if( orderedResult == null )
+				return Array.Empty<SimpleMeasurementDto>();
+
+			return filter.LimitResult < 0 ? orderedResult : orderedResult.Take( filter.LimitResult );
+		}
+
+		/// <summary>
+		/// Sort the measurements according to the order criteria. Start a new OrderBy-chain.
+		/// </summary>
+		private static IOrderedEnumerable<SimpleMeasurementDto> StartAttributeOrderChain( OrderDto order, IEnumerable<SimpleMeasurementDto> source )
+		{
+			return order.Direction switch
+			{
+				OrderDirectionDto.Asc => source.OrderBy( SelectAttributeValues( order ) ),
+				OrderDirectionDto.Desc => source.OrderByDescending( SelectAttributeValues( order ) ),
+				_ => throw new ArgumentOutOfRangeException( nameof( order.Direction ) )
+			};
+		}
+
+		/// <summary>
+		/// Sort the measurements according to the order criteria. Chain it to a previous result.
+		/// </summary>
+		private static IOrderedEnumerable<SimpleMeasurementDto> AppendAttributeOrderChain( OrderDto order, IOrderedEnumerable<SimpleMeasurementDto> orderedSource )
+		{
+			return order.Direction switch
+			{
+				OrderDirectionDto.Asc => orderedSource.ThenBy( SelectAttributeValues( order ) ),
+				OrderDirectionDto.Desc => orderedSource.ThenByDescending( SelectAttributeValues( order ) ),
+				_ => throw new ArgumentOutOfRangeException( nameof( order.Direction ) )
+			};
+		}
+
+		private static Func<SimpleMeasurementDto, object> SelectAttributeValues( OrderDto order )
+		{
+			if( order.Attribute == WellKnownKeys.Measurement.Time )
+			{
+				return m => m.Time;
+			}
+
+			return m => m.Attributes.FirstOrDefault( a => a.Key == order.Attribute )?.Value;
 		}
 
 		private async Task PollOperationStatus( string statusId, CancellationToken cancellationToken = default )
@@ -680,7 +747,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 					.Select( request => _RestClient.Request<SimpleMeasurementDto[]>( request, cancellationToken ) );
 				var result = await Task.WhenAll( requests ).ConfigureAwait( false );
 
-				return result.SelectMany( r => r ).ToArray();
+				return LimitAndSortResult( result.SelectMany( r => r ), filter, result.Length ).ToArray();
 			}
 
 			// split multiple part uuids into chunks of uuids using multiple requests to avoid "Request-URI Too Long" exception
@@ -701,7 +768,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 					.Select( request => _RestClient.Request<SimpleMeasurementDto[]>( request, cancellationToken ) );
 				var result = await Task.WhenAll( requests ).ConfigureAwait( false );
 
-				return result.SelectMany( r => r ).ToArray();
+				return LimitAndSortResult( result.SelectMany( r => r ), filter, result.Length ).ToArray();
 			}
 
 			{
@@ -840,7 +907,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 
 				foreach( var uuids in ArrayHelper.Split( measurementUuids, targetSize, RestClientHelper.LengthOfListElementInUri ) )
 				{
-					var parameter = new List<ParameterDefinition>{ ParameterDefinition.Create( "measurementUuids", RestClientHelper.ConvertGuidListToString( uuids ) ) };
+					var parameter = new List<ParameterDefinition> { ParameterDefinition.Create( "measurementUuids", RestClientHelper.ConvertGuidListToString( uuids ) ) };
 					await DeleteMeasurementsInternal( parameter, cancellationToken ).ConfigureAwait( false );
 				}
 			}


### PR DESCRIPTION
Issue: #93 
Consider LimitResult and OrderBy when combining results of multiple queries which are part of one request which wa split due to URI length restriction.

Situation: Request measurements for many parts. Since the URI would get too long we split the request into multiple ones using the same filter criterias, e.g LimtResult=20. Each request will yield 20 measurements in correct order. Until now the results were simply combined into one array, which resultetd in 60 measurements instead of 20 and the order was not correct.

Fix: In the case of splitting a request we now evaluate the limit and sort the result according to requested order.