### PR TITLE
Feature/create raw data returns info

### DIFF
--- a/src/Api.Rest.Tests/HttpClient/Data/DataServiceRestClientTest.cs
+++ b/src/Api.Rest.Tests/HttpClient/Data/DataServiceRestClientTest.cs
@@ -68,8 +68,8 @@ namespace Zeiss.PiWeb.Api.Rest.Tests.HttpClient.Data
 					{ Attributes = new[] { new AttributeDto( 5, 3 ), new AttributeDto( 55, 20 ), new AttributeDto( 999, 3 ) } }
 			};
 
-			server.RegisterReponse( "/DataServiceRest/measurements?partUuids=%7B11111111-1111-1111-1111-111111111111%7D&order=5%20Asc%2C55%20Asc", JsonConvert.SerializeObject( firstMeasurementSet ) );
-			server.RegisterReponse( "/DataServiceRest/measurements?partUuids=%7B22222222-2222-2222-2222-222222222222%7D&order=5%20Asc%2C55%20Asc", JsonConvert.SerializeObject( secondMeasurementSet ) );
+			server.RegisterResponse( "/DataServiceRest/measurements?partUuids=%7B11111111-1111-1111-1111-111111111111%7D&order=5%20Asc%2C55%20Asc", JsonConvert.SerializeObject( firstMeasurementSet ) );
+			server.RegisterResponse( "/DataServiceRest/measurements?partUuids=%7B22222222-2222-2222-2222-222222222222%7D&order=5%20Asc%2C55%20Asc", JsonConvert.SerializeObject( secondMeasurementSet ) );
 
 			var result = await client.GetMeasurements( filter: new MeasurementFilterAttributesDto
 			{
@@ -97,8 +97,8 @@ namespace Zeiss.PiWeb.Api.Rest.Tests.HttpClient.Data
 
 			var secondMeasurementSet = new[] { new SimpleMeasurementDto(), new SimpleMeasurementDto(), new SimpleMeasurementDto() };
 
-			server.RegisterReponse( "/DataServiceRest/measurements?partUuids=%7B11111111-1111-1111-1111-111111111111%7D&limitResult=5&order=4%20Desc", JsonConvert.SerializeObject( firstMeasurementSet ) );
-			server.RegisterReponse( "/DataServiceRest/measurements?partUuids=%7B22222222-2222-2222-2222-222222222222%7D&limitResult=5&order=4%20Desc", JsonConvert.SerializeObject( secondMeasurementSet ) );
+			server.RegisterResponse( "/DataServiceRest/measurements?partUuids=%7B11111111-1111-1111-1111-111111111111%7D&limitResult=5&order=4%20Desc", JsonConvert.SerializeObject( firstMeasurementSet ) );
+			server.RegisterResponse( "/DataServiceRest/measurements?partUuids=%7B22222222-2222-2222-2222-222222222222%7D&limitResult=5&order=4%20Desc", JsonConvert.SerializeObject( secondMeasurementSet ) );
 
 			var result = await client.GetMeasurements( filter: new MeasurementFilterAttributesDto
 			{

--- a/src/Api.Rest.Tests/HttpClient/RawData/RawDataServiceRestClientTest.cs
+++ b/src/Api.Rest.Tests/HttpClient/RawData/RawDataServiceRestClientTest.cs
@@ -1,0 +1,130 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2021                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Tests.HttpClient.RawData
+{
+	#region usings
+
+	using System;
+	using System.Text;
+	using System.Threading.Tasks;
+	using Newtonsoft.Json;
+	using Newtonsoft.Json.Converters;
+	using NUnit.Framework;
+	using Zeiss.PiWeb.Api.Rest.Dtos;
+	using Zeiss.PiWeb.Api.Rest.Dtos.RawData;
+	using Zeiss.PiWeb.Api.Rest.HttpClient.RawData;
+
+	#endregion
+
+	[TestFixture]
+	public class RawDataServiceRestClientTest
+	{
+		#region constants
+
+		private const int Port = 8081;
+		private const int MaxUriLength = 80;
+
+		#endregion
+
+		#region members
+
+		private static readonly Uri Uri = new Uri( $"http://localhost:{Port}/" );
+
+		#endregion
+
+		#region methods
+
+		[Test]
+		public async Task CreateRawData_SupportsResult_ReturnsResultWithKey()
+		{
+			var md5 = Guid.Parse( "FFC45AA8-7CFC-43D8-B159-D388B63AABD9" );
+			var partUuid = Guid.Parse( "4F8C6FF6-9A94-4C54-A7E0-4B277758BAD3" );
+			var data = Encoding.UTF8.GetBytes( "bar" );
+			const int key = 42;
+
+			var input = new RawDataInformationDto
+			{
+				Created = DateTime.Now,
+				FileName = "foo.txt",
+				Key = null,
+				LastModified = DateTime.Now,
+				MD5 = md5,
+				MimeType = "text/plain",
+				Size = data.Length,
+				Target = new RawDataTargetEntityDto { Entity = RawDataEntityDto.Part, Uuid = partUuid.ToString() }
+			};
+			var expected = new RawDataInformationDto( input ) { Key = key };
+
+			using var webServer = WebServer.StartNew( Port );
+			RegisterRawDataServiceVersionResponse( webServer, "1.7.0" );
+			RegisterCreateRawDataResponse( webServer, partUuid, expected );
+
+			using var sut = new RawDataServiceRestClient( Uri, MaxUriLength );
+			var actual = await sut.CreateRawData( input, data );
+
+			Assert.That( actual.Key, Is.EqualTo( key ) );
+		}
+
+		[Test]
+		public async Task CreateRawData_NotSupportsResult_ReturnsResultWithKey()
+		{
+			var md5 = Guid.Parse( "FFC45AA8-7CFC-43D8-B159-D388B63AABD9" );
+			var partUuid = Guid.Parse( "4F8C6FF6-9A94-4C54-A7E0-4B277758BAD3" );
+			var data = Encoding.UTF8.GetBytes( "bar" );
+			const int key = 42;
+
+			var input = new RawDataInformationDto
+			{
+				Created = DateTime.Now,
+				FileName = "foo.txt",
+				Key = null,
+				LastModified = DateTime.Now,
+				MD5 = md5,
+				MimeType = "text/plain",
+				Size = data.Length,
+				Target = new RawDataTargetEntityDto { Entity = RawDataEntityDto.Part, Uuid = partUuid.ToString() }
+			};
+			var expected = new RawDataInformationDto( input ) { Key = key };
+
+			using var webServer = WebServer.StartNew( Port );
+			RegisterRawDataServiceVersionResponse( webServer, "1.6.0" );
+			RegisterListRawDataResponse( webServer, partUuid, new[] { expected } );
+
+			using var sut = new RawDataServiceRestClient( Uri, MaxUriLength );
+			var actual = await sut.CreateRawData( input, data );
+
+			Assert.That( actual.Key, Is.EqualTo( key ) );
+		}
+
+		private static void RegisterRawDataServiceVersionResponse( WebServer webServer, string version )
+		{
+			var interfaceVersionRange = new InterfaceVersionRange { SupportedVersions = new[] { new Version( version ) } };
+			var responseJson = JsonConvert.SerializeObject( interfaceVersionRange, new VersionConverter() );
+			webServer.RegisterResponse( "/RawDataServiceRest/", responseJson );
+		}
+
+		private static void RegisterCreateRawDataResponse( WebServer webServer, Guid partUuid, RawDataInformationDto responseObject )
+		{
+			var url = $"/RawDataServiceRest/rawData/Part/{partUuid}";
+			var responseJson = JsonConvert.SerializeObject( responseObject );
+			webServer.RegisterResponse( url, responseJson );
+		}
+
+		private static void RegisterListRawDataResponse( WebServer webServer, Guid partUuid, RawDataInformationDto[] responseObject )
+		{
+			var url = $"/RawDataServiceRest/rawData/Part?uuids=%7B{partUuid}%7D";
+			var responseJson = JsonConvert.SerializeObject( responseObject );
+			webServer.RegisterResponse( url, responseJson );
+		}
+
+		#endregion
+	}
+}

--- a/src/Api.Rest.Tests/SimpleRequestTest.cs
+++ b/src/Api.Rest.Tests/SimpleRequestTest.cs
@@ -58,7 +58,7 @@ namespace Zeiss.PiWeb.Api.Rest.Tests
 
 			var config = Fixture.Create<ConfigurationDto>();
 
-			server.RegisterReponse( "/DataServiceRest/configuration", JsonConvert.SerializeObject( config ) );
+			server.RegisterResponse( "/DataServiceRest/configuration", JsonConvert.SerializeObject( config ) );
 
 			// when
 			var result = await client.GetConfiguration();

--- a/src/Api.Rest.Tests/WebServer.cs
+++ b/src/Api.Rest.Tests/WebServer.cs
@@ -75,14 +75,14 @@ namespace Zeiss.PiWeb.Api.Rest.Tests
 			} );
 		}
 
-		public void RegisterReponse( string uri, Func<string> response )
+		public void RegisterResponse( string uri, Func<string> response )
 		{
 			_Responses[ uri ] = response;
 		}
 
-		public void RegisterReponse( string uri, string response )
+		public void RegisterResponse( string uri, string response )
 		{
-			RegisterReponse( uri, () => response );
+			RegisterResponse( uri, () => response );
 		}
 
 		private string CreateResponse( HttpListenerRequest request )

--- a/src/Api.Rest/Contracts/IRawDataServiceRestClientBase.cs
+++ b/src/Api.Rest/Contracts/IRawDataServiceRestClientBase.cs
@@ -13,7 +13,6 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 	#region usings
 
 	using System;
-	using System.Collections.Generic;
 	using System.Threading;
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
@@ -124,7 +123,7 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		/// <remarks>
 		/// If key speciefied by <see cref="RawDataInformationDto.Key"/> is -1, a new key will be chosen by the server automatically. This is the preferred way.
 		/// </remarks>
-		Task CreateRawData( [NotNull] RawDataInformationDto info, [NotNull] byte[] data, CancellationToken cancellationToken = default );
+		Task<RawDataInformationDto> CreateRawData( [NotNull] RawDataInformationDto info, [NotNull] byte[] data, CancellationToken cancellationToken = default );
 
 		/// <summary>
 		/// Updates the raw data object <paramref name="data"/> for the element identified by <paramref name="info"/>.

--- a/src/Api.Rest/Contracts/RawDataServiceFeatureMatrix.cs
+++ b/src/Api.Rest/Contracts/RawDataServiceFeatureMatrix.cs
@@ -45,6 +45,8 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 
 		public static Version GetRawDataInformationRequestPathMinVersion { get; } = new Version( SupportedMajorVersion, 7 );
 
+		public static Version CreateRawDataResultMinVersion { get; } = new Version( SupportedMajorVersion, 7 );
+
 		public bool SupportsRawDataAttributeFilter => CurrentInterfaceVersion >= RawDataAttributeFilterMinVersion;
 
 		public bool SupportsArchiveLookup => CurrentInterfaceVersion >= RawDataArchiveLookupMinVersion;
@@ -52,6 +54,8 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		public bool SupportsUpdateRawDataInformation => CurrentInterfaceVersion >= UpdateRawDataInformationMinVersion;
 
 		public bool SupportsGetRawDataInformationRequestPath => CurrentInterfaceVersion >= GetRawDataInformationRequestPathMinVersion;
+
+		public bool SupportsCreateRawDataResult => CurrentInterfaceVersion >= CreateRawDataResultMinVersion;
 
 		#endregion
 	}


### PR DESCRIPTION
When sending a `POST` request to the `RawDataService` in order to create a raw data, the endpoint with a minimum version of 1.7.0 responds a `RawDataInformationDto` object containing the key. This PR enables the `RawDataServiceRestClient` to respond this object. For endpoint versions younger than 1.7.0 a separate request is made internally which determines the result object so the user of the method can rely on having a response object in both version cases.