### PR TITLE
Add parameter LimitResultPerPart to filter classes

### DIFF
--- a/src/Api.Rest.Dtos/Data/AbstractMeasurementFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/AbstractMeasurementFilterAttributesDto.cs
@@ -24,6 +24,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 		public const string PartUuidsParamName = "partUuids";
 		protected const string DeepParamName = "deep";
 		protected const string LimitResultParamName = "limitResult";
+		protected const string LimitResultPerPartParamName = "limitResultPerPart";
 		protected const string OrderByParamName = "order";
 		public const string MeasurementUuidsParamName = "measurementUuids";
 		protected const string SearchConditionParamName = "searchCondition";
@@ -42,6 +43,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 		{
 			Deep = false;
 			LimitResult = -1;
+			LimitResultPerPart = -1;
 			OrderBy = new[] { new OrderDto( 4, OrderDirectionDto.Desc, EntityDto.Measurement ) };
 			AggregationMeasurements = AggregationMeasurementSelectionDto.Default;
 		}
@@ -65,6 +67,11 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 		/// Gets or sets the maximum number of measurements that should be returned. If this value is -1, no limit is used.
 		/// </summary>
 		public int LimitResult { get; set; }
+
+		/// <summary>
+		/// Restricts the number of sub-items for each found part of the result (Default: -1).
+		/// </summary>
+		public int LimitResultPerPart { get; set; }
 
 		/// <summary>
 		/// Gets or sets the sort order of the resulting measurements.

--- a/src/Api.Rest.Dtos/Data/DistinctMeasurementFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/DistinctMeasurementFilterAttributesDto.cs
@@ -50,7 +50,8 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 			string searchCondition,
 			string aggregation,
 			string fromModificationDate,
-			string toModificationDate )
+			string toModificationDate,
+			string limitResultPerPart = "-1" )
 		{
 			var items = new[]
 			{
@@ -58,6 +59,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 				Tuple.Create( MeasurementUuidsParamName, measurementUuids ),
 				Tuple.Create( DeepParamName, deep ),
 				Tuple.Create( LimitResultParamName, limitResult ),
+				Tuple.Create( LimitResultPerPartParamName, limitResultPerPart ),
 				Tuple.Create( OrderByParamName, order ),
 				Tuple.Create( SearchConditionParamName, searchCondition ),
 				Tuple.Create( AggregationParamName, aggregation ),
@@ -86,6 +88,9 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 							break;
 						case LimitResultParamName:
 							result.LimitResult = int.Parse( value, CultureInfo.InvariantCulture );
+							break;
+						case LimitResultPerPartParamName:
+							result.LimitResultPerPart = int.Parse( value, CultureInfo.InvariantCulture );
 							break;
 						case OrderByParamName:
 							result.OrderBy = value.Split( ',' ).Select( element => OrderDtoParser.Parse( element, EntityDto.Measurement ) ).ToArray();
@@ -128,6 +133,9 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 			if( LimitResult >= 0 )
 				result.Add( ParameterDefinition.Create( LimitResultParamName, LimitResult.ToString() ) );
 
+			if( LimitResultPerPart >= 0 )
+				result.Add( ParameterDefinition.Create( LimitResultPerPartParamName, LimitResultPerPart.ToString() ) );
+
 			if( MeasurementUuids != null && MeasurementUuids.Length > 0 )
 				result.Add( ParameterDefinition.Create( MeasurementUuidsParamName, RestClientHelper.ConvertGuidListToString( MeasurementUuids ) ) );
 
@@ -158,6 +166,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 				PartUuids = PartUuids,
 				Deep = Deep,
 				LimitResult = LimitResult,
+				LimitResultPerPart = LimitResultPerPart,
 				OrderBy = OrderBy,
 				SearchCondition = SearchCondition,
 				MeasurementUuids = MeasurementUuids,

--- a/src/Api.Rest.Dtos/Data/MeasurementFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/MeasurementFilterAttributesDto.cs
@@ -107,7 +107,8 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 			string toModificationDate,
 			string mergeAttributes,
 			string mergeCondition,
-			string mergeMasterPart )
+			string mergeMasterPart,
+			string limitResultPerPart = "-1")
 		{
 			var items = new[]
 			{
@@ -115,6 +116,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 				Tuple.Create( MeasurementUuidsParamName, measurementUuids ),
 				Tuple.Create( DeepParamName, deep ),
 				Tuple.Create( LimitResultParamName, limitResult ),
+				Tuple.Create( LimitResultPerPartParamName, limitResultPerPart ),
 				Tuple.Create( OrderByParamName, order ),
 				Tuple.Create( RequestedMeasurementAttributesParamName, requestedMeasurementAttributes ),
 				Tuple.Create( SearchConditionParamName, searchCondition ),
@@ -148,6 +150,9 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 							break;
 						case LimitResultParamName:
 							result.LimitResult = int.Parse( value, CultureInfo.InvariantCulture );
+							break;
+						case LimitResultPerPartParamName:
+							result.LimitResultPerPart = int.Parse( value, CultureInfo.InvariantCulture );
 							break;
 						case RequestedMeasurementAttributesParamName:
 							result.RequestedMeasurementAttributes = new AttributeSelector( RestClientHelper.ConvertStringToUInt16List( value ) );
@@ -203,6 +208,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 				PartUuids = PartUuids,
 				Deep = Deep,
 				LimitResult = LimitResult,
+				LimitResultPerPart = LimitResultPerPart,
 				OrderBy = OrderBy,
 				RequestedMeasurementAttributes = RequestedMeasurementAttributes,
 				SearchCondition = SearchCondition,
@@ -226,6 +232,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 				PartUuids = PartUuids,
 				Deep = Deep,
 				LimitResult = LimitResult,
+				LimitResultPerPart = LimitResultPerPart,
 				OrderBy = OrderBy,
 				RequestedMeasurementAttributes = RequestedMeasurementAttributes,
 				SearchCondition = SearchCondition,
@@ -252,6 +259,9 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 
 			if( LimitResult >= 0 )
 				result.Add( ParameterDefinition.Create( LimitResultParamName, LimitResult.ToString() ) );
+
+			if( LimitResultPerPart >= 0 )
+				result.Add( ParameterDefinition.Create( LimitResultPerPartParamName, LimitResultPerPart.ToString() ) );
 
 			if( MeasurementUuids != null && MeasurementUuids.Length > 0 )
 				result.Add( ParameterDefinition.Create( MeasurementUuidsParamName, RestClientHelper.ConvertGuidListToString( MeasurementUuids ) ) );

--- a/src/Api.Rest.Dtos/Data/MeasurementValueFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/MeasurementValueFilterAttributesDto.cs
@@ -115,7 +115,8 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 			string toModificationDate,
 			string mergeAttributes,
 			string mergeCondition,
-			string mergeMasterPart )
+			string mergeMasterPart,
+			string limitResultPerPart = "-1" )
 		{
 			var items = new[]
 			{
@@ -124,6 +125,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 				Tuple.Create( CharacteristicsUuidListParamName, characteristicUuids ),
 				Tuple.Create( DeepParamName, deep ),
 				Tuple.Create( LimitResultParamName, limitResult ),
+				Tuple.Create( LimitResultPerPartParamName, limitResultPerPart ),
 				Tuple.Create( OrderByParamName, order ),
 				Tuple.Create( RequestedValueAttributesParamName, requestedValueAttributes ),
 				Tuple.Create( RequestedMeasurementAttributesParamName, requestedMeasurementAttributes ),
@@ -160,6 +162,9 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 							break;
 						case LimitResultParamName:
 							result.LimitResult = short.Parse( value, CultureInfo.InvariantCulture );
+							break;
+						case LimitResultPerPartParamName:
+							result.LimitResultPerPart = int.Parse( value, CultureInfo.InvariantCulture );
 							break;
 						case RequestedValueAttributesParamName:
 							result.RequestedValueAttributes = new AttributeSelector( RestClientHelper.ConvertStringToUInt16List( value ) );
@@ -212,6 +217,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 				PartUuids = PartUuids,
 				Deep = Deep,
 				LimitResult = LimitResult,
+				LimitResultPerPart = LimitResultPerPart,
 				CharacteristicsUuidList = CharacteristicsUuidList,
 				OrderBy = OrderBy,
 				RequestedValueAttributes = RequestedValueAttributes,
@@ -240,6 +246,9 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 
 			if( LimitResult >= 0 )
 				result.Add( ParameterDefinition.Create( LimitResultParamName, LimitResult.ToString() ) );
+
+			if( LimitResultPerPart >= 0 )
+				result.Add( ParameterDefinition.Create( LimitResultPerPartParamName, LimitResultPerPart.ToString() ) );
 
 			if( MeasurementUuids != null && MeasurementUuids.Length > 0 )
 				result.Add( ParameterDefinition.Create( MeasurementUuidsParamName, RestClientHelper.ConvertGuidListToString( MeasurementUuids ) ) );

--- a/src/Api.Rest/Contracts/DataServiceFeatureMatrix.cs
+++ b/src/Api.Rest/Contracts/DataServiceFeatureMatrix.cs
@@ -52,6 +52,9 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		//Request asynchronous deletion of measurements and check status with long polling.
 		public static readonly Version AsyncMeasurementDeletionMinVersion = new Version( SupportedMajorVersion, 7 );
 
+		//Request using a limit per part when fetching measurements.
+		public static readonly Version LimitResultPerPartMinVersion = new Version( SupportedMajorVersion, 8 );
+
 		#endregion
 
 		#region constructors
@@ -84,6 +87,8 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		public bool SupportClearPart => CurrentInterfaceVersion >= ClearPartMinVersion;
 
 		public bool SupportsAsyncMeasurementDeletion => CurrentInterfaceVersion >= AsyncMeasurementDeletionMinVersion;
+
+		public bool SupportsLimitResultPerPart => CurrentInterfaceVersion >= LimitResultPerPartMinVersion;
 
 		#endregion
 	}


### PR DESCRIPTION
New parameter for measurement search: LimitResultPerPart.
- in combination with a part path and deep this will trigger a search for all child parts and return the specified amount of measurements per part
- in combination with a list of part uuids this will return the specified amount of measurements per part uuid