### PR TITLE
[PIWEB-14814] fix: Correctly throw TimeoutException on timeout only

### DIFF
--- a/src/Api.Rest/Common/Client/RestClientBase.cs
+++ b/src/Api.Rest/Common/Client/RestClientBase.cs
@@ -318,11 +318,6 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 			{
 				throw new RestClientException( $"Error fetching web service response for request [{request?.RequestUri}]: {ex.Message}", ex );
 			}
-			catch( TaskCanceledException ex ) when( !cancellationToken.IsCancellationRequested )
-			{
-				// we expect the TaskCanceledException to be a timeout if the passed token has not been canceled
-				throw new TimeoutException( "Timeout reached", ex );
-			}
 			finally
 			{
 				if( autoDisposeResponse )
@@ -478,9 +473,14 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 			};
 #endif
 
-			_HttpClient = new HttpClient( _WebRequestHandler )
+			var timeoutHandler = new TimeoutHandler
 			{
 				Timeout = timeout ?? DefaultTimeout,
+				InnerHandler = _WebRequestHandler
+			};
+			
+			_HttpClient = new HttpClient( timeoutHandler )
+			{
 				BaseAddress = ServiceLocation
 			};
 		}

--- a/src/Api.Rest/Common/Client/TimeoutHandler.cs
+++ b/src/Api.Rest/Common/Client/TimeoutHandler.cs
@@ -1,0 +1,82 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2021                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Common.Client
+{
+	#region usings
+
+	using System;
+	using System.Net.Http;
+	using System.Threading;
+	using System.Threading.Tasks;
+
+	#endregion
+
+	/// <summary>
+	/// Responsible for correctly handling timeouts for HttpClient requests.
+	/// </summary>
+	/// <remarks>
+	/// Unfortunately there is no easy way to recognize hitting a timeout rather than a normal cancellation for HttpClient requests.
+	/// In .NET 5.0 Microsoft finally added a way to recognize the timeout by checking the inner exception for being a TimeoutException.
+	/// So this http handler mimes that fix by using its own cancellation token for setting up the timeout, so that way the timeout can
+	/// easily be recognized and it works also for frameworks before .NET 5.0.
+	///
+	/// More can be read here:
+	/// https://github.com/dotnet/runtime/issues/21965
+	/// https://github.com/dotnet/runtime/pull/2281
+	/// </remarks>
+	public sealed class TimeoutHandler : DelegatingHandler
+	{
+		#region properties
+
+		/// <summary>
+		/// Gets or sets the timespan to wait before the request times out.
+		/// </summary>
+		public TimeSpan Timeout { get; set; }
+
+		#endregion
+
+		#region methods
+
+		/// <inheritdoc />
+		protected override async Task<HttpResponseMessage> SendAsync( HttpRequestMessage request, CancellationToken cancellationToken )
+		{
+			using( var cts = GetCancellationTokenSource( cancellationToken ) )
+			{
+				var timeoutTime = cts is null
+					? 0
+					: Environment.TickCount + Timeout.Ticks / TimeSpan.TicksPerMillisecond;
+
+				try
+				{
+					return await base.SendAsync( request, cts?.Token ?? cancellationToken );
+				}
+				catch( OperationCanceledException ex ) when( !cancellationToken.IsCancellationRequested && Environment.TickCount >= timeoutTime )
+				{
+					throw new TimeoutException(
+						$"The request was canceled due to the configured timeout of {Timeout.TotalSeconds} seconds elapsing.", ex );
+				}
+			}
+		}
+
+		private CancellationTokenSource GetCancellationTokenSource( CancellationToken cancellationToken )
+		{
+			if( Timeout == System.Threading.Timeout.InfiniteTimeSpan )
+				// No need to create a CTS if there's no timeout
+				return null;
+
+			var cts = CancellationTokenSource.CreateLinkedTokenSource( cancellationToken );
+			cts.CancelAfter( Timeout );
+			return cts;
+		}
+
+		#endregion
+	}
+}


### PR DESCRIPTION
This PR fixes a bug where a `TimeoutException` is thrown in cases there was no timeout. 

This happened due to the reason there was no built-in way to recognize whether a request was canceled due to timeout or a normal cancellation. There was a workaround checking the passed `CancellationToken` which worked in most cases, but did not work if the `HttpClient` was disposed with pending requests. But in `.NET 5.0` Microsoft finally added a way to recognize the timeout by checking the inner exception for being a `TimeoutException`. This fix was used as base for fixing the issue by using a custom `HttpMessageHandler` which does now handle the timeout instead of the `HttpClient` itself.

details can be found here:
https://github.com/dotnet/runtime/issues/21965
https://github.com/dotnet/runtime/pull/2281

External PiWeb-Bugtracker:
https://bugtracker.zeiss-izm.de/browse/PIWEB-14814