### PR TITLE
[PIWEB-14814] fix: Fix potential deadlocking

### DIFF
--- a/src/Api.Rest/Common/Client/RestClientBase.cs
+++ b/src/Api.Rest/Common/Client/RestClientBase.cs
@@ -73,6 +73,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 		private readonly bool _Chunked;
 
 		private HttpClient _HttpClient;
+		private TimeoutHandler _TimeoutHandler;
 		private HttpClientHandler _WebRequestHandler;
 		private bool _IsDisposed;
 		private AuthenticationContainer _AuthenticationContainer = new AuthenticationContainer( AuthenticationMode.NoneOrBasic );
@@ -119,12 +120,12 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 		/// </summary>
 		public TimeSpan Timeout
 		{
-			get => _HttpClient.Timeout;
+			get => _TimeoutHandler.Timeout;
 			set
 			{
-				if( _HttpClient.Timeout != value )
+				if( _TimeoutHandler.Timeout != value )
 				{
-					_HttpClient.Timeout = value;
+					_TimeoutHandler.Timeout = value;
 				}
 			}
 		}
@@ -433,7 +434,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 
 		private void RebuildHttpClient()
 		{
-			var timeout = _HttpClient.Timeout;
+			var timeout = _TimeoutHandler.Timeout;
 
 			_HttpClient?.Dispose();
 			_WebRequestHandler?.Dispose();
@@ -473,14 +474,15 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 			};
 #endif
 
-			var timeoutHandler = new TimeoutHandler
+			_TimeoutHandler = new TimeoutHandler
 			{
 				Timeout = timeout ?? DefaultTimeout,
 				InnerHandler = _WebRequestHandler
 			};
-			
-			_HttpClient = new HttpClient( timeoutHandler )
+
+			 _HttpClient = new HttpClient( _TimeoutHandler )
 			{
+				Timeout = System.Threading.Timeout.InfiniteTimeSpan,
 				BaseAddress = ServiceLocation
 			};
 		}

--- a/src/Api.Rest/Common/Client/TimeoutHandler.cs
+++ b/src/Api.Rest/Common/Client/TimeoutHandler.cs
@@ -56,7 +56,8 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 
 				try
 				{
-					return await base.SendAsync( request, cts?.Token ?? cancellationToken );
+					return await base.SendAsync( request, cts?.Token ?? cancellationToken )
+						.ConfigureAwait( false );
 				}
 				catch( OperationCanceledException ex ) when( !cancellationToken.IsCancellationRequested && Environment.TickCount >= timeoutTime )
 				{


### PR DESCRIPTION
This PR prevents a potential deadlock when invoking requests from synchronous contexts. It also ensures now that the internal `HttpClient` timeout is set infinite.