### PR TITLE
feat: extend FeatureMatrix to support multiple supported major versions

### DIFF
--- a/src/Api.Rest.Tests/Contracts/FeatureMatrixTest.cs
+++ b/src/Api.Rest.Tests/Contracts/FeatureMatrixTest.cs
@@ -1,0 +1,75 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZfM Dresden)                   */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2021                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Tests.Contracts
+{
+	#region usings
+
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using FluentAssertions;
+	using NUnit.Framework;
+	using Zeiss.PiWeb.Api.Rest.Contracts;
+	using Zeiss.PiWeb.Api.Rest.Dtos;
+
+	#endregion
+
+	[TestFixture]
+	public class FeatureMatrixTest
+	{
+		#region methods
+
+		[Test]
+		[TestCase( "1.3", new[] { 1 }, "1.3" )]
+		[TestCase( "1.3, 1.5, 2.0, 2.2", new[] { 1 }, "1.5" )]
+		[TestCase( "1.3, 1.5, 2.0, 2.2", new[] { 1, 2 }, "2.2" )]
+		[TestCase( "1.3, 1.5, 2.0, 2.2", new[] { 2 }, "2.2" )]
+		public void Test_GetBestKnownVersion_ReturnsCorrectVersion( string interfaceVersions, int[] supportedMajorVersions, string expectedBestKnownVersion )
+		{
+			// Given
+			var interfaceVersionRange = new InterfaceVersionRange { SupportedVersions = ParseVersions( interfaceVersions ) };
+			var expectedVersion = new Version( expectedBestKnownVersion );
+
+			// When
+			var bestKnownVersion = FeatureMatrix.GetBestKnownVersion( interfaceVersionRange, supportedMajorVersions );
+
+			// Then
+			bestKnownVersion.Should().Be( expectedVersion );
+		}
+
+		[Test]
+		[TestCase( "1.3", new[] { 2 } )]
+		[TestCase( "2.0, 2.2", new[] { 1 } )]
+		public void Test_GetBestKnownVersion_ThrowsServerApiNotSupportedException( string interfaceVersions, int[] supportedMajorVersions )
+		{
+			// Given
+			var interfaceVersionRange = new InterfaceVersionRange { SupportedVersions = ParseVersions( interfaceVersions ) };
+
+			// When
+			Action getBestKnownVersion = () => FeatureMatrix.GetBestKnownVersion( interfaceVersionRange, supportedMajorVersions );
+
+			// Then
+			getBestKnownVersion.Should().Throw<ServerApiNotSupportedException>();
+		}
+
+		private static IEnumerable<Version> ParseVersions( string versionsString )
+		{
+			var versions = string.IsNullOrEmpty( versionsString )
+				? Enumerable.Empty<Version>()
+				: versionsString.Split( ',' )
+					.Select( versionString => new Version( versionString.Trim() ) );
+
+			return versions;
+		}
+
+		#endregion
+	}
+}

--- a/src/Api.Rest/Contracts/DataServiceFeatureMatrix.cs
+++ b/src/Api.Rest/Contracts/DataServiceFeatureMatrix.cs
@@ -25,35 +25,35 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 	{
 		#region members
 
-		// Deleting of measuremnts for sub parts is possible if server supports at least this minor version
-		public static readonly Version DeleteMeasurementsForSubPartsMinVersion = new Version( SupportedMajorVersion, 2 );
+		// Deleting of measurements for sub parts is possible if server supports at least this version
+		public static readonly Version DeleteMeasurementsForSubPartsMinVersion = new Version( 1, 2 );
 
-		// Creating version entries on creating parts or characteristics is possible if server supports at least this minor version
-		public static readonly Version CreateVersionEntriesOnCreatinPartsOrCharacteristicsMinVersion = new Version( SupportedMajorVersion, 2 );
+		// Creating version entries on creating parts or characteristics is possible if server supports at least this version
+		public static readonly Version CreateVersionEntriesOnCreatinPartsOrCharacteristicsMinVersion = new Version( 1, 2 );
 
-		// Checking if an attribute with a given value exists is possible if server supports at least this minor version
-		public static readonly Version CheckAttributeUsageMinVersion = new Version( SupportedMajorVersion, 2 );
+		// Checking if an attribute with a given value exists is possible if server supports at least this version
+		public static readonly Version CheckAttributeUsageMinVersion = new Version( 1, 2 );
 
-		// Fetching a list of characteristics via uuid restriction is possible if server supports at least this minor version
-		public static readonly Version CharacteristicUuidRestrictionForCharacteristicFetchMinVersion = new Version( SupportedMajorVersion, 3 );
+		// Fetching a list of characteristics via uuid restriction is possible if server supports at least this version
+		public static readonly Version CharacteristicUuidRestrictionForCharacteristicFetchMinVersion = new Version( 1, 3 );
 
-		// Restrict a measurement search by merge attributes is possible if server supports at least this minor version
-		public static readonly Version RestrictMeasurementSearchByMergeAttributesMinVersion = new Version( SupportedMajorVersion, 2 );
+		// Restrict a measurement search by merge attributes is possible if server supports at least this version
+		public static readonly Version RestrictMeasurementSearchByMergeAttributesMinVersion = new Version( 1, 2 );
 
-		// Restrict a measurement search by distinct attributes is possible if server supports at least this minor version
-		public static readonly Version DistinctMeasurementAttributsValuesSearchMinVersion = new Version( SupportedMajorVersion, 2 );
+		// Restrict a measurement search by distinct attributes is possible if server supports at least this version
+		public static readonly Version DistinctMeasurementAttributsValuesSearchMinVersion = new Version( 1, 2 );
 
-		//Restrict a measurement search by merge master part if server supports at least this minor version
-		public static readonly Version RestrictMeasurementSearchByMergeMasterPartMinVersion = new Version( SupportedMajorVersion, 4 );
+		// Restrict a measurement search by merge master part if server supports at least this version
+		public static readonly Version RestrictMeasurementSearchByMergeMasterPartMinVersion = new Version( 1, 4 );
 
-		//Clearing a part
-		public static readonly Version ClearPartMinVersion = new Version( SupportedMajorVersion, 5 );
+		// Clearing a part
+		public static readonly Version ClearPartMinVersion = new Version( 1, 5 );
 
-		//Request asynchronous deletion of measurements and check status with long polling.
-		public static readonly Version AsyncMeasurementDeletionMinVersion = new Version( SupportedMajorVersion, 7 );
+		// Request asynchronous deletion of measurements and check status with long polling.
+		public static readonly Version AsyncMeasurementDeletionMinVersion = new Version( 1, 7 );
 
-		//Request using a limit per part when fetching measurements.
-		public static readonly Version LimitResultPerPartMinVersion = new Version( SupportedMajorVersion, 8 );
+		// Request using a limit per part when fetching measurements.
+		public static readonly Version LimitResultPerPartMinVersion = new Version( 1, 8 );
 
 		#endregion
 

--- a/src/Api.Rest/Contracts/RawDataServiceFeatureMatrix.cs
+++ b/src/Api.Rest/Contracts/RawDataServiceFeatureMatrix.cs
@@ -36,16 +36,16 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 
 		#region properties
 
-		// If the server supports at least this minor version filtering is possible.
-		public static Version RawDataAttributeFilterMinVersion { get; } = new Version( SupportedMajorVersion, 2 );
+		// If the server supports at least this version filtering is possible.
+		public static Version RawDataAttributeFilterMinVersion { get; } = new Version( 1, 2 );
 
-		public static Version RawDataArchiveLookupMinVersion { get; } = new Version( SupportedMajorVersion, 5 );
+		public static Version RawDataArchiveLookupMinVersion { get; } = new Version( 1, 5 );
 
-		public static Version UpdateRawDataInformationMinVersion { get; } = new Version( SupportedMajorVersion, 7 );
+		public static Version UpdateRawDataInformationMinVersion { get; } = new Version( 1, 7 );
 
-		public static Version GetRawDataInformationRequestPathMinVersion { get; } = new Version( SupportedMajorVersion, 7 );
+		public static Version GetRawDataInformationRequestPathMinVersion { get; } = new Version( 1, 7 );
 
-		public static Version CreateRawDataResultMinVersion { get; } = new Version( SupportedMajorVersion, 7 );
+		public static Version CreateRawDataResultMinVersion { get; } = new Version( 1, 7 );
 
 		public bool SupportsRawDataAttributeFilter => CurrentInterfaceVersion >= RawDataAttributeFilterMinVersion;
 


### PR DESCRIPTION
This PR extends the FeatureMatrix to be able to:
* handle major versions other than "1"
* handle multiple supported major versions