### PR TITLE
[PIWEB-15232] feat: Remove email from identity string

### DIFF
--- a/src/Api.Rest/Common/Utilities/OAuthHelper.cs
+++ b/src/Api.Rest/Common/Utilities/OAuthHelper.cs
@@ -55,12 +55,27 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Utilities
 			return new JwtSecurityToken( jwtEncodedString );
 		}
 
+		public static IEnumerable<Claim> GetClaimsFromSecurityToken( string jwtEncodedString )
+		{
+			return DecodeSecurityToken( jwtEncodedString ).Claims;
+		}
+
 		public static string IdentityClaimsToFriendlyText( IList<Claim> claims )
 		{
-			var name = claims.SingleOrDefault( claim => claim.Type == "name" )?.Value;
-			var email = claims.SingleOrDefault( claim => claim.Type == "email" )?.Value;
+			var name = IdentityClaimsToUsername( claims );
+			var email = IdentityClaimsToEmail( claims );
 
 			return $"{name} ({email})";
+		}
+
+		public static string IdentityClaimsToEmail( IList<Claim> claims )
+		{
+			return claims.SingleOrDefault( claim => claim.Type == "email" )?.Value;
+		}
+
+		public static string IdentityClaimsToUsername( IList<Claim> claims )
+		{
+			return claims.SingleOrDefault( claim => claim.Type == "name" )?.Value;
 		}
 
 		public static string TokenToFriendlyText( string jwtEncodedString )
@@ -70,11 +85,28 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Utilities
 
 			try
 			{
-				var decodedToken = DecodeSecurityToken( jwtEncodedString );
-				if( decodedToken != null )
-				{
-					return IdentityClaimsToFriendlyText( decodedToken.Claims.ToList() );
-				}
+				var claims = GetClaimsFromSecurityToken( jwtEncodedString ).ToList();
+
+				return IdentityClaimsToFriendlyText( claims );
+			}
+			catch
+			{
+				// ignored
+			}
+
+			return "";
+		}
+
+		public static string TokenToUsername( string jwtEncodedString )
+		{
+			if( string.IsNullOrEmpty( jwtEncodedString ) )
+				return "";
+
+			try
+			{
+				var claims = GetClaimsFromSecurityToken( jwtEncodedString ).ToList();
+
+				return IdentityClaimsToUsername( claims );
 			}
 			catch
 			{
@@ -91,11 +123,9 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Utilities
 
 			try
 			{
-				var decodedToken = DecodeSecurityToken( jwtEncodedString );
-				if( decodedToken != null )
-				{
-					return decodedToken.Claims.SingleOrDefault( c => string.Equals( c.Type, "email" ) )?.Value;
-				}
+				var claims = GetClaimsFromSecurityToken( jwtEncodedString ).ToList();
+
+				return IdentityClaimsToEmail( claims );
 			}
 			catch
 			{


### PR DESCRIPTION
~This PR changes that the identity string of a user only contains the display name rather than the display name + the email address.
There is no need to add the email address to the identity string, since there is already a separate field in the `OAuthTokenCredentials` for it which can be used if needed.~
This PR adds a new `Username` property to the `OAuthTokenCredential` class. As suggested in the comment below this property is meant to be used as user friendly way to display the username, since it does not also contain the email address.
Since all the API is public, I chose to not change existing methods and constructors, but rather add new ones where applicable.