### PR TITLE
fix creation of ServerApiNotSupportedException in FeatureMatrix

### DIFF
--- a/src/Api.Rest.Tests/Contracts/FeatureMatrixTest.cs
+++ b/src/Api.Rest.Tests/Contracts/FeatureMatrixTest.cs
@@ -46,8 +46,8 @@ namespace Zeiss.PiWeb.Api.Rest.Tests.Contracts
 		}
 
 		[Test]
-		[TestCase( "1.3", new[] { 2 }, ServerApiNotSupportedReason.VersionsTooHigh )]
-		[TestCase( "2.0, 2.2", new[] { 1 }, ServerApiNotSupportedReason.VersionsTooLow )]
+		[TestCase( "1.3", new[] { 2 }, ServerApiNotSupportedReason.VersionsTooLow )]
+		[TestCase( "2.0, 2.2", new[] { 1 }, ServerApiNotSupportedReason.VersionsTooHigh )]
 		[TestCase( "1.3, 3.2", new[] { 2 }, ServerApiNotSupportedReason.VersionsNotSupported )]
 		[TestCase( "", new[] { 1, 2 }, ServerApiNotSupportedReason.VersionsNotSupported )]
 		[TestCase( "1.3, 3.2", new int[ 0 ], ServerApiNotSupportedReason.VersionsNotSupported )]

--- a/src/Api.Rest/Contracts/FeatureMatrix.cs
+++ b/src/Api.Rest/Contracts/FeatureMatrix.cs
@@ -70,15 +70,15 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 			if ( bestKnownVersion != null )
 				return bestKnownVersion;
 
-			var versionsTooNew = interfaceVersionRange.SupportedVersions.All( version =>
-				supportedMajorVersions.All( supportedMajorVersion => version.Major > supportedMajorVersion ) );
+			var versionsTooNew = interfaceVersionRange.SupportedVersions.All( interfaceVersion =>
+				supportedMajorVersions.All( supportedMajorVersion => interfaceVersion.Major > supportedMajorVersion ) );
 			if ( versionsTooNew )
-				throw new ServerApiNotSupportedException( interfaceVersionRange, supportedMajorVersions, ServerApiNotSupportedReason.VersionsTooLow );
-
-			var versionsTooOld = interfaceVersionRange.SupportedVersions.All( version =>
-				supportedMajorVersions.All( supportedMajorVersion => version.Major < supportedMajorVersion ) );
-			if ( versionsTooOld )
 				throw new ServerApiNotSupportedException( interfaceVersionRange, supportedMajorVersions, ServerApiNotSupportedReason.VersionsTooHigh );
+
+			var versionsTooOld = interfaceVersionRange.SupportedVersions.All( interfaceVersion =>
+				supportedMajorVersions.All( supportedMajorVersion => interfaceVersion.Major < supportedMajorVersion ) );
+			if ( versionsTooOld )
+				throw new ServerApiNotSupportedException( interfaceVersionRange, supportedMajorVersions, ServerApiNotSupportedReason.VersionsTooLow );
 
 			throw new ServerApiNotSupportedException( interfaceVersionRange, supportedMajorVersions );
 		}


### PR DESCRIPTION
This PR fixes a bug where the reason for a ServerApiNotSupportedException was switched by accident when creating an ServerApiNotSupportedException in class FeatureMatrix.