### PR TITLE
fix: caching for .net core

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -233,6 +233,7 @@ Task("Pack_Client")
             new NuSpecContent { Source = "net5.0/Zeiss.PiWeb.Api.Rest.xml", Target = "lib/net5.0" },
         },
         Dependencies             = new [] {
+            new NuSpecDependency { Id = "CacheCow.Client", Version = "2.8.3" },
             new NuSpecDependency { Id = "Newtonsoft.Json", Version = "12.0.3" },
             new NuSpecDependency { Id = "Newtonsoft.Json.Bson", Version = "1.0.2" },
             new NuSpecDependency { Id = "IdentityModel", Version = "5.1.0" },

--- a/src/Api.Rest/Api.Rest.csproj
+++ b/src/Api.Rest/Api.Rest.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
 
   <ItemGroup Label="NuGet references">
+    <PackageReference Include="CacheCow.Client" Version="2.8.3" />
     <PackageReference Include="IdentityModel" Version="5.1.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
     <PackageReference Include="Microsoft.IdentityModel.Logging" Version="6.11.1" />

--- a/src/Api.Rest/Common/Client/FilesystemCacheStore.cs
+++ b/src/Api.Rest/Common/Client/FilesystemCacheStore.cs
@@ -1,0 +1,187 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2021                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Common.Client
+{
+	#region usings
+
+	using System;
+	using System.Collections.Generic;
+	using System.IO;
+	using System.Net.Http;
+	using System.Threading.Tasks;
+	using CacheCow.Client;
+	using CacheCow.Common;
+
+	#endregion
+
+	/// <summary>
+	/// Implements <see cref="ICacheStore"/> and stores the cache in a filesystem directory, managed by the operating system.
+	/// </summary>
+	public class FilesystemCacheStore : ICacheStore
+	{
+		#region constants
+
+		private const string CacheFileExtension = ".piweb~cache";
+
+		#endregion
+
+		#region members
+
+		private readonly MessageContentHttpMessageSerializer _HttpMessageSerializer = new( true );
+
+		#endregion
+
+		#region constructors
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="FilesystemCacheStore"/> class
+		/// and uses a default path based on the temporary directory as cache store.
+		/// </summary>
+		public FilesystemCacheStore()
+		{
+			StoragePath = Path.Combine( Path.GetTempPath(), "Cache" );
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="FilesystemCacheStore"/> class
+		/// and uses a specified path as cache store.
+		/// </summary>
+		/// <param name="path">
+		/// The path of the directory that is used as cache store.
+		/// The directory should be empty or contain only cached files.
+		/// If the directory does not exist, it will be created.
+		/// </param>
+		/// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null" />.</exception>
+		/// <exception cref="ArgumentException"><paramref name="path"/> is invalid or not accessible.</exception>
+		public FilesystemCacheStore( string path )
+		{
+			if( path == null )
+				throw new ArgumentNullException( nameof( path ) );
+
+			try
+			{
+				Directory.CreateDirectory( path );
+				StoragePath = path;
+			}
+			catch( Exception exception )
+			{
+				throw new ArgumentException( @$"Failed to use the path '{path}' as cache store.", nameof( path ), exception );
+			}
+		}
+
+		#endregion
+
+		#region properties
+
+		/// <summary>
+		/// Gets the path of the directory that is used as cache store.
+		/// </summary>
+		public string StoragePath { get; }
+
+		#endregion
+
+		#region methods
+
+		private string GetCacheFileFullName( CacheKey key )
+		{
+			var hash = key.HashBase64.Replace( '/', '-' );
+			return Path.Combine( StoragePath, hash + CacheFileExtension );
+		}
+
+		#endregion
+
+		#region interface ICacheStore
+
+		/// <inheritdoc/>
+		public async Task<HttpResponseMessage> GetValueAsync( CacheKey key )
+		{
+			try
+			{
+				using var stream = File.Open( GetCacheFileFullName( key ), FileMode.Open, FileAccess.Read, FileShare.Read );
+				return await _HttpMessageSerializer.DeserializeToResponseAsync( stream ).ConfigureAwait( false );
+			}
+			catch
+			{
+				// no matter what happened, pretend it is not cached
+				return null;
+			}
+		}
+
+		/// <inheritdoc/>
+		public async Task AddOrUpdateAsync( CacheKey key, HttpResponseMessage response )
+		{
+			try
+			{
+				using var stream = File.Open( GetCacheFileFullName( key ), FileMode.Create, FileAccess.Write, FileShare.None );
+				await _HttpMessageSerializer.SerializeAsync( response, stream ).ConfigureAwait( false );
+			}
+			catch
+			{
+				// nothing to do, don't cache if not possible
+			}
+		}
+
+		/// <inheritdoc/>
+		public Task<bool> TryRemoveAsync( CacheKey key )
+		{
+			try
+			{
+				var fileFullName = GetCacheFileFullName( key );
+
+				if( !File.Exists( fileFullName ) )
+					return Task.FromResult( false );
+
+				File.Delete( fileFullName );
+				return Task.FromResult( true );
+			}
+			catch
+			{
+				return Task.FromResult( false );
+			}
+		}
+
+		/// <inheritdoc/>
+		public Task ClearAsync()
+		{
+			IEnumerable<string> files;
+			try
+			{
+				files = Directory.EnumerateFiles( StoragePath, "*" + CacheFileExtension, SearchOption.TopDirectoryOnly );
+			}
+			catch
+			{
+				return Task.CompletedTask;
+			}
+
+			foreach( var file in files )
+			{
+				try
+				{
+					File.Delete( file );
+				}
+				catch
+				{
+					// nothing to do, don't delete if not possible
+				}
+			}
+
+			return Task.CompletedTask;
+		}
+
+		/// <inheritdoc/>
+		public void Dispose()
+		{
+			GC.SuppressFinalize( this );
+		}
+
+		#endregion
+	}
+}


### PR DESCRIPTION
Enables caching for .Net Core, using the "CacheCow". This PR also includes a simple `FilesystemCacheStore`, since CacheCow only provides an `InMemoryCacheStore`.