### PR TITLE
feat: Make PiWeb-Api to support also being used in browser (WASM)

### DIFF
--- a/src/Api.Definitions/Api.Definitions.csproj
+++ b/src/Api.Definitions/Api.Definitions.csproj
@@ -36,6 +36,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
   </ItemGroup>
 

--- a/src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
+++ b/src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
@@ -37,6 +37,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SauceControl.InheritDoc" Version="1.3.0">

--- a/src/Api.Rest/Api.Rest.csproj
+++ b/src/Api.Rest/Api.Rest.csproj
@@ -43,6 +43,10 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
 
+  <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
+
   <ItemGroup Label=".NET references" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>


### PR DESCRIPTION
This PR adds support for the PiWeb-Api being used from within the browser using web assembly by disabling all options that are not supported directly in browsers.
Additionally there is now support for passing an optional HTTP message handler into the REST client object to gain access to the message object for each request for handling built-in features which was not possible before.

[See also](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/blazor/call-web-api.md#httpclient-and-httprequestmessage-with-fetch-api-request-options-2)