### PR TITLE
Change parameter data type in CheckCatalogEntryUsage

### DIFF
--- a/src/Api.Rest/Contracts/IDataServiceRestClientBase.cs
+++ b/src/Api.Rest/Contracts/IDataServiceRestClientBase.cs
@@ -94,13 +94,13 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		Task<bool> CheckAttributeUsage( ushort attributeKey, string value, CancellationToken cancellationToken = default );
 
 		/// <summary>
-		/// Method checks if there is any entry for attribute <paramref name="attributeKey"/> and catalog entry with index <paramref name="catalogEntryIndex"/>
+		/// Method checks if there is any entry for attribute <paramref name="attributeKey"/> and catalog entry with key (index) <paramref name="catalogEntryKey"/>
 		/// </summary>
 		/// <param name="attributeKey">The attribute key which should be checked.</param>
-		/// <param name="catalogEntryIndex">The index of the catalog entry which should be checked.</param>
+		/// <param name="catalogEntryKey">The key (index) of the catalog entry which should be checked.</param>
 		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
 		/// <returns></returns>
-		Task<bool> CheckCatalogEntryUsage( ushort attributeKey, int catalogEntryIndex, CancellationToken cancellationToken = default );
+		Task<bool> CheckCatalogEntryUsage( ushort attributeKey, short catalogEntryKey, CancellationToken cancellationToken = default );
 
 		/// <summary>
 		/// Method for fetching all <see cref="CatalogDto"/>s.  The catalogs contain the definition and the catalog entries.

--- a/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
@@ -502,12 +502,12 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 		}
 
 		/// <inheritdoc />
-		public Task<bool> CheckCatalogEntryUsage( ushort attributeKey, int catalogEntryIndex, CancellationToken cancellationToken = default )
+		public Task<bool> CheckCatalogEntryUsage( ushort attributeKey, short catalogEntryKey, CancellationToken cancellationToken = default )
 		{
-			if( catalogEntryIndex < 0 )
-				throw new InvalidOperationException( $"Unable to check catalogue entry usage. {nameof( catalogEntryIndex )} must be equal or greater than 0." );
+			if( catalogEntryKey < 0 )
+				throw new InvalidOperationException( $"Unable to check catalogue entry usage. {nameof( catalogEntryKey )} must be equal or greater than 0." );
 
-			return CheckAttributeUsageInternal( attributeKey, catalogEntryIndex.ToString(), cancellationToken );
+			return CheckAttributeUsageInternal( attributeKey, catalogEntryKey.ToString(), cancellationToken );
 		}
 
 		/// <inheritdoc />


### PR DESCRIPTION
- catalog entry key is of datatype short, not int, see issue #6
- also renamed it to key since this is the term used in CatalogEntryDto