### PR TITLE
Add GitHub actions for different workflows

### DIFF
--- a/.github/workflows/build-and-pack.yml
+++ b/.github/workflows/build-and-pack.yml
@@ -1,0 +1,70 @@
+﻿# Build, test and pack the source code as a nuget.
+
+name: Build, test & pack
+
+on:
+  workflow_call:
+    inputs:
+      configuration:
+        description: 'Define whether this is a debug or a release build.'
+        required: true
+        type: string
+      prerelease:
+        description: 'Define if this is a prerelease.'
+        required: true
+        type: string
+      publish_target:
+        description: 'Define the publish target (GitHub/nuget.org).'
+        required: true
+        type: string
+
+defaults:
+  run:
+    working-directory: src
+
+jobs:
+  compute-version:
+    uses: ./.github/workflows/gitversion.yml
+    with:
+      prerelease: ${{ inputs.prerelease }}
+
+
+  build-and-pack:
+
+    needs: compute-version
+    # TODO. Currently some test fails on Ubuntu
+    runs-on: windows-latest
+    
+    steps:      
+    - uses: actions/checkout@v3
+           
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 5.0.x #TODO Currently net6.0 breaks AppVeyor build
+        
+    - name: Restore dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: dotnet build --no-restore -c ${{ inputs.configuration }}
+      
+    - name: Test
+      run: dotnet test --no-build --verbosity normal -c ${{ inputs.configuration }}
+      
+    - name: Pack
+      run: dotnet pack --no-restore --no-build -o package_output -c ${{ inputs.configuration }} -p:PackageVersion=${{ needs.compute-version.outputs.package_version }} #lets test azure feed
+      
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: packages
+        path: src/package_output/*.nupkg
+        
+  publish:
+    needs: build-and-pack
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    uses: ./.github/workflows/publish.yml
+    with:
+      target: ${{ inputs.publish_target }}
+    secrets: inherit

--- a/.github/workflows/build-and-pack.yml
+++ b/.github/workflows/build-and-pack.yml
@@ -13,6 +13,10 @@ on:
         description: 'Define if this is a prerelease.'
         required: true
         type: string
+      suffix:
+        description: 'Define the prerelease suffix, e.g. alpha.'
+        required: true
+        type: string
       publish_target:
         description: 'Define the publish target (GitHub/nuget.org).'
         required: true
@@ -27,6 +31,7 @@ jobs:
     uses: ./.github/workflows/gitversion.yml
     with:
       prerelease: ${{ inputs.prerelease }}
+      suffix: ${{ inputs.suffix }}
 
 
   build-and-pack:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,79 @@
+﻿# Create a stable API NuGet release. This workflow is manually triggered.
+
+name: Create release
+
+# Run on manual trigger only
+on:
+  workflow_dispatch:
+
+jobs:
+  compute-version:
+    uses: ./.github/workflows/gitversion.yml
+    with:
+      prerelease: "false"
+
+  release-flow:
+    needs: compute-version
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          
+      - name: Output nuget version to variable
+        run: |
+          echo "NUGET_VERSION=${{ needs.compute-version.outputs.package_version }}" >> $GITHUB_ENV
+
+      - name: Setup git config
+        run: |
+          # setup the username and email. We use the 'GitHub Actions Bot'
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          
+      - name: Start release branch
+        run: |
+          git checkout develop
+          git checkout -b release/${{ env.NUGET_VERSION }}
+          
+      - name: Commit and merge changes
+        run: |
+          echo Change version number, commit and push
+          sed -i 's#<PackageVersion>[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]#<PackageVersion>${{ env.NUGET_VERSION }}#g' ./src/Api.Definitions/Api.Definitions.csproj
+          sed -i 's#<AssemblyVersion>[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]#<AssemblyVersion>${{ env.NUGET_VERSION }}#g' ./src/Api.Definitions/Api.Definitions.csproj
+          sed -i 's#<AssemblyVersion>[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]#<PackageVersion>${{ env.NUGET_VERSION }}#g' ./src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
+          sed -i 's#<AssemblyVersion>[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]#<AssemblyVersion>${{ env.NUGET_VERSION }}#g' ./src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
+          sed -i 's#<AssemblyVersion>[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]#<PackageVersion>${{ env.NUGET_VERSION }}#g' ./src/Api.Rest/Api.Rest.csproj
+          sed -i 's#<AssemblyVersion>[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]#<AssemblyVersion>${{ env.NUGET_VERSION }}#g' ./src/Api.Rest/Api.Rest.csproj
+          git add ./src/Api.Definitions/Api.Definitions.csproj
+          git add ./src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
+          git add ./src/Api.Rest/Api.Rest.csproj
+          git commit -m "Raises version number to ${{ env.NUGET_VERSION }}"
+          echo Checkout master
+          git checkout master
+          echo Merge release into master
+          git merge --no-ff release/${{ env.NUGET_VERSION }}
+          echo Tag release commit
+          git tag v${{ env.NUGET_VERSION }}
+          echo Checkout develop
+          git checkout develop
+          echo Merge back master into develop
+          git merge --no-ff master
+          
+      - name: Push all branches
+        run: |
+          git checkout master
+          git push origin master --tags
+          git checkout develop
+          git push origin develop
+          git checkout release/${{ env.NUGET_VERSION }}
+          git push origin release/${{ env.NUGET_VERSION }}
+          
+  build-and-publish:
+    needs: release-flow
+    uses: ./.github/workflows/build-and-pack.yml
+    with:
+      configuration: "Release"
+      prerelease: "false"
+      publish_target: "nuget.org"
+    secrets: inherit

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -75,5 +75,6 @@ jobs:
     with:
       configuration: "Release"
       prerelease: "false"
+      suffix: "stable"
       publish_target: "nuget.org"
     secrets: inherit

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,18 @@
+﻿# Workflow to build and publish the develop branch
+
+name: Build on develop
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  develop:
+    uses: ./.github/workflows/build-and-pack.yml
+    with:
+      configuration: "Debug"
+      prerelease: "true"
+      publish_target: "GitHub"
+    secrets: inherit

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -14,5 +14,6 @@ jobs:
     with:
       configuration: "Debug"
       prerelease: "true"
-      publish_target: "GitHub"
+      suffix: "beta"
+      publish_target: "nuget.org"
     secrets: inherit

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -1,0 +1,37 @@
+﻿# Workflow to build and publish feaute/fix branches
+
+name: Build on feature/fix branch
+
+# Run on manual trigger only
+on:
+  workflow_dispatch:
+
+jobs:
+  get-feature-branch:
+  
+    runs-on: ubuntu-latest
+    outputs:
+      branch_name: ${{ steps.normalize.outputs.branch_name }}
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    # Remove feature/fix branch prefix, hyphens etc. and trim to 20 characters
+    - name: Normalize branch name
+      run: |
+        branch="${{ github.ref_name }}"
+        noSlashes=`echo $branch | sed "s/[^[:alnum:]]//g"`
+        noFeature="${noSlashes/feature/}"
+        noFix="${noFeature/fix/}"
+        echo "::set-output name=branch_name::$( echo $noFix | cut -c 1-20 )"
+      id: normalize
+
+  feature-branch:
+    needs: get-feature-branch
+    uses: ./.github/workflows/build-and-pack.yml
+    with:
+      configuration: "Debug"
+      prerelease: "true"
+      suffix: "alpha-${{ needs.get-feature-branch.outputs.branch_name }}"
+      publish_target: "None"
+    secrets: inherit

--- a/.github/workflows/gitversion.yml
+++ b/.github/workflows/gitversion.yml
@@ -9,6 +9,10 @@ on:
         description: 'Define if this is a prerelease.'
         required: true
         type: string
+      suffix:
+        description: 'Define the prerelease suffix, e.g. alpha.'
+        required: true
+        type: string
     outputs:
       package_version:
         description: "Computed version for the package (SemVer)"
@@ -40,7 +44,7 @@ jobs:
     - name: Append prerelease suffix
       if: inputs.prerelease == 'true'
       run: |
-        echo "::set-output name=prerelease_suffix::-alpha$(printf %4s ${{ steps.gitversion.outputs.increment }} | tr ' ' 0).${{ github.run_number }}-${{ github.run_attempt }}"
+        echo "::set-output name=prerelease_suffix::-${{ inputs.suffix }}$(printf %4s ${{ steps.gitversion.outputs.increment }} | tr ' ' 0).${{ github.run_number }}-${{ github.run_attempt }}"
       id: prerelease_version
       
     - name: Output version

--- a/.github/workflows/gitversion.yml
+++ b/.github/workflows/gitversion.yml
@@ -1,0 +1,49 @@
+﻿# Compute nuget version using GitVersion.
+
+name: GitVersion
+
+on:
+  workflow_call:
+    inputs:
+      prerelease:
+        description: 'Define if this is a prerelease.'
+        required: true
+        type: string
+    outputs:
+      package_version:
+        description: "Computed version for the package (SemVer)"
+        value: ${{ jobs.nuget-version.outputs.version_output }}
+        
+defaults:
+  run:
+    working-directory: src
+    
+jobs:
+  nuget-version:
+
+    runs-on: ubuntu-latest
+    outputs:
+      version_output: ${{ steps.nuget_version.outputs.final_version }}
+    
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        
+    - name: Git Versioning
+      id: gitversion
+      uses: paulhatch/semantic-version@v4.0.2
+      with:
+        format: "${major}.${minor}.${patch}"
+        
+    # Format is X.X.X-alpha000X.X-X, e.g. 8.1.0-alpha0008.42-1, where 0008 means 8 commits since last tag, 42 is the github run number and 1 is the build try.
+    - name: Append prerelease suffix
+      if: inputs.prerelease == 'true'
+      run: |
+        echo "::set-output name=prerelease_suffix::-alpha$(printf %4s ${{ steps.gitversion.outputs.increment }} | tr ' ' 0).${{ github.run_number }}-${{ github.run_attempt }}"
+      id: prerelease_version
+      
+    - name: Output version
+      run: |
+           echo "::set-output name=final_version::${{ steps.gitversion.outputs.version }}${{ steps.prerelease_version.outputs.prerelease_suffix }}"
+      id: nuget_version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+﻿# Publish the build artifact (Nuget) to a target nuget feed.
+
+name: Publish-Artifact
+
+on:
+  workflow_call:
+    inputs:
+      target:
+        description: 'Define the target feed to push the artifact.'
+        required: true
+        type: string
+
+jobs: 
+  nuget-org-publish:
+  
+    if: inputs.target == 'nuget.org'
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x
+    - name: Download nugets from artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: packages
+        path: package_output
+    - name: Push to nuget.org
+      run: dotnet nuget push package_output/*.nupkg --skip-duplicate --no-symbols --api-key ${{ secrets.NUGET_FEED_PAT }} --source https://api.nuget.org/v3/index.json

--- a/src/Api.Definitions/Api.Definitions.csproj
+++ b/src/Api.Definitions/Api.Definitions.csproj
@@ -34,6 +34,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>ZEISS PiWeb API</PackageTags>
     <Version>$(InformationalVersion)</Version>
+    <RepositoryUrl>https://github.com/ZEISS-PiWeb/PiWeb-Api</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
+++ b/src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
@@ -35,6 +35,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>ZEISS PiWeb Dtos</PackageTags>
     <Version>$(InformationalVersion)</Version>
+    <RepositoryUrl>https://github.com/ZEISS-PiWeb/PiWeb-Api</RepositoryUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Api.Rest/Api.Rest.csproj
+++ b/src/Api.Rest/Api.Rest.csproj
@@ -37,6 +37,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>ZEISS PiWeb API</PackageTags>
     <Version>$(InformationalVersion)</Version>
+    <RepositoryUrl>https://github.com/ZEISS-PiWeb/PiWeb-Api</RepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This PR adds different workflows using GitHub Actions.

Workflows:
- Build, test and pack PRs to develop branch
- Publish alpha package to GitHub feed on push to develop (aka merging a PR)
- GitVersion computes correct version for nuget
- Create-Release workflow to automatically create a release and publish it to nuget.org
- Adds RepositoryUrl to .csproj since it is needed for the GitHub nuget feed

Further TODOs:
- #170
- #171