### PR TITLE
List of characteristic values in DataMeasurementDto should not be null

### DIFF
--- a/src/Api.Rest.Dtos/Data/DataMeasurementDto.cs
+++ b/src/Api.Rest.Dtos/Data/DataMeasurementDto.cs
@@ -25,15 +25,26 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 	/// </summary>
 	public class DataMeasurementDto : SimpleMeasurementDto
 	{
+		#region members
+
+		// Newtonsoft.Json is not able to create an empty dictionary if the property is not set.
+		// If Newtonsoft.Json support is discontinued, this initialization should no longer be necessary.
+		[NotNull] private IReadOnlyDictionary<Guid, DataValueDto> _Characteristics = new Dictionary<Guid, DataValueDto>();
+
+		#endregion
+
 		#region properties
 
 		/// <summary>
 		/// Gets or sets the measurement values.
 		/// </summary>
-		[CanBeNull]
 		[JsonProperty( "characteristics" )]
 		[JsonPropertyName( "characteristics" )]
-		public IReadOnlyDictionary<Guid, DataValueDto> Characteristics { get; set; }
+		public IReadOnlyDictionary<Guid, DataValueDto> Characteristics
+		{
+			[NotNull] get => _Characteristics;
+			set => _Characteristics = value ?? new Dictionary<Guid, DataValueDto>();
+		}
 
 		#endregion
 	}


### PR DESCRIPTION
The list of characteristic values in `DataMeasurementDto` should not return `null` like in previous versions.