### PR TITLE
Update build and build doc

### DIFF
--- a/.github/workflows/build-and-pack.yml
+++ b/.github/workflows/build-and-pack.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
       publish_target:
-        description: 'Define the publish target (GitHub/nuget.org).'
+        description: 'Define the publish target (None/nuget.org).'
         required: true
         type: string
 
@@ -58,7 +58,7 @@ jobs:
       run: dotnet test --no-build --verbosity normal -c ${{ inputs.configuration }}
       
     - name: Pack
-      run: dotnet pack --no-restore --no-build -o package_output -c ${{ inputs.configuration }} -p:PackageVersion=${{ needs.compute-version.outputs.package_version }} #lets test azure feed
+      run: dotnet pack --no-restore --no-build -o package_output -c ${{ inputs.configuration }} -p:PackageVersion=${{ needs.compute-version.outputs.package_version }}
       
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/gitversion.yml
+++ b/.github/workflows/gitversion.yml
@@ -40,11 +40,11 @@ jobs:
       with:
         format: "${major}.${minor}.${patch}"
         
-    # Format is X.X.X-alpha000X.X-X, e.g. 8.1.0-alpha0008.42-1, where 0008 means 8 commits since last tag, 42 is the github run number and 1 is the build try.
+    # Format is X.X.X-alpha000X-X, e.g. 8.1.0-alpha0008-42, where 0008 means 8 commits since last tag and 42 is the github run number.
     - name: Append prerelease suffix
       if: inputs.prerelease == 'true'
       run: |
-        echo "::set-output name=prerelease_suffix::-${{ inputs.suffix }}$(printf %4s ${{ steps.gitversion.outputs.increment }} | tr ' ' 0).${{ github.run_number }}-${{ github.run_attempt }}"
+        echo "::set-output name=prerelease_suffix::-${{ inputs.suffix }}$(printf %4s ${{ steps.gitversion.outputs.increment }} | tr ' ' 0)-${{ github.run_number }}"
       id: prerelease_version
       
     - name: Output version

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,70 +4,46 @@ Building PiWeb API
 TL;DR
 -----
 
-* do development on "develop" branch or feature branches called "feature/<cool_new_feature>"
-* do NOT do development on "master" branch
-* use GitHub forks and pull requests, but do NOT merge to "master" branch
-    * use development or feature branches instead
+* do development on feature branches called "feature/<cool_new_feature>"
+* use GitHub forks and pull requests, pushing directly to master or develop is not possible
 * put release notes into WHATSNEW.txt
-* tag public versions with tags including the version number
-    * beta releases with "v<version_number>-beta.n", e.g. "v1.1.0-beta10"
-    * official releases with "v<version_number>", e.g. "v1.0.1"
-* NuGet package is automatically built by AppVeyor 
-* publish NuGet package from AppVeyor to nuget.org
-* merge official release tag to master branch
+* NuGet packages are automatically built by GitHub
+* merging a PR automatically publishes the beta-NuGets to nuget.org
 
 Comprehensive
 -------------
 
 PiWeb API is a .NET library packaged as NuGet. The NuGet packages are built automatically using
-[AppVeyor](https://ci.appveyor.com/project/czjlorenz/piweb-api). There is also a build badge on
+[GitHub Actions](https://github.com/ZEISS-PiWeb/PiWeb-Api/actions). There is also a build badge on
 the README.md front page like this:
 
-[![Build status](https://ci.appveyor.com/api/projects/status/q48run5x0ge40h9p?svg=true)](https://ci.appveyor.com/project/czjlorenz/piweb-api)
+[![Build on develop](https://github.com/ZEISS-PiWeb/PiWeb-Api/actions/workflows/develop.yml/badge.svg?branch=develop&event=push)](https://github.com/ZEISS-PiWeb/PiWeb-Api/actions/workflows/develop.yml)
 
 PiWeb API uses a branching model called
 [Git Flow](http://nvie.com/posts/a-successful-git-branching-model/)
 in order to provide bug fixes for stable releases. This means that the master branch
 only contains stable code. Any development work is done either on a branch called "develop"
-or on separate feature branches called "feature/<cool_new_feature>". Hotfixes are done
-on branches called "hotfix/<bug_description>". Stabilization work towards a new
+or on separate feature branches called "feature/<cool_new_feature>". Fixes are done
+on branches called "fix/<bug_description>". Stabilization work towards a new
 release (if required) is done on branches called "release/<target_version>". Once a
-release is ready for deployment a tag called "v<version_number>", e.g. "v1.0.0", is
-created. This tag is merged to the master branch. Therefore the master branch only
-contains stable release code.
+release is ready for deployment, the "Create-Release" workflow is triggered manually.
+This creates a release branch (if not already present), and a tag called "v<version_number>", e.g. "v1.0.0".
+The tag and branch is then merged to the master branch.
+Therefore the master branch only contains stable release code.
 
 This branching model was first described by Vincent Driessen in
 his blog entry
 [A successful Git branching model](http://nvie.com/posts/a-successful-git-branching-model/).
-A good overview and comparison with the simplifed
+A good overview and comparison with the simplified
 [Github flow](https://guides.github.com/introduction/flow/) can be found in the blog entry
 [Git Flow vs Github flow](https://lucamezzalira.com/2014/03/10/git-flow-vs-github-flow/).
 
 Version numbers of assembly and nuget package follow the rules set by
 [semantic versioning](https://semver.org/). They are automatically created
-from tags in the git repository using
-[GitVersion](https://gitversion.readthedocs.io/en/latest/examples/).
+from tags, commits and commit messages in the git repository using
+[GitVersion](https://gitversion.net/docs/).
 
 The contents of the file WHATSNEW.txt is put into the release notes section
-of the nuget. So in order to tell the users about the great new features
-in the new version put a description into this file.
-
-The build scripting should support GitHub flow as well as long as tags with version
-numbers are created. You should be aware that with GitHub flow only bugfixes for the
-current release are possible.
-
-Unstable and release nuget packages are created by [AppVeyor](https://ci.appveyor.com/project/czjlorenz/piweb-api).
-The AppVeyor [project feed](https://ci.appveyor.com/nuget/piweb-api) provides
-an easy way to consume any built version including unstable versions.
-Stable release nuget packages are meant to be deployed to nuget.org making them
-official.
-
-
-Known Issues
-------------
-
-In case the NuGet version is wrong, GitVersion and AppVeyor have an known incompatibility.
-See issue [1289|https://github.com/GitTools/GitVersion/issues/1289] in GitVersion project.
-This is fixed in the latest beta build v4.0.0-beta.13 of GitVersion which unfortunately
-is not available on nuget.org. The workaround is not to have multiple branches pointing
-to the very same commit.
+of the main NuGet (Zeiss.PiWeb.Api.Rest). Sub-packages like Dtos and Definitions both have their own
+WHATSNEW.txt file for their respective changes. So in order to tell the users about the great new features
+in the new version put a description into the correct file.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 PiWeb-Api
 =========
 
-[![Build status](https://ci.appveyor.com/api/projects/status/q48run5x0ge40h9p/branch/master?svg=true&passingText=master%20-%20OK&pendingText=master%20-%20PENDING&failingText=master%20-%20FAILED)](https://ci.appveyor.com/project/czjlorenz/piweb-api/branch/master)
-[![Build status](https://ci.appveyor.com/api/projects/status/q48run5x0ge40h9p/branch/develop?svg=true&passingText=develop%20-%20OK&pendingText=develop%20-%20PENDING&failingText=develop%20-%20FAILED)](https://ci.appveyor.com/project/czjlorenz/piweb-api/branch/develop)
+[![Build on develop](https://github.com/ZEISS-PiWeb/PiWeb-Api/actions/workflows/develop.yml/badge.svg?branch=develop&event=push)](https://github.com/ZEISS-PiWeb/PiWeb-Api/actions/workflows/develop.yml)
 
 <p align="center">
   <img src="https://github.com/ZEISS-PiWeb/PiWeb-Api/blob/master/Logo.png" />
@@ -37,6 +36,11 @@ Release Notes for our REST API can be found on their particular documentation pa
 You can select the right version with the dropdown in the upper right corner. Release notes are displayed directly at the top of the page.
 
 Release Notes for our .NET SDK NuGet are available on [NuGet.org](https://www.nuget.org/packages/Zeiss.PiWeb.Api.Rest/).
+
+### Contributing
+
+Feel free to contribute to the PiWeb API SDK. For further information about our workflow take a look at the [BUILDING.md](https://github.com/ZEISS-PiWeb/PiWeb-Api/blob/develop/BUILDING.md).
+
 
 <hr>
 

--- a/src/Api.Definitions/Api.Definitions.csproj
+++ b/src/Api.Definitions/Api.Definitions.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet package specifications for local build">
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb; .xml;</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder); .xml;</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <Authors>$(Company)</Authors>
     <EmbedAllSources>true</EmbedAllSources>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
+++ b/src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet package specifications for local build">
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb; .xml;</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder); .xml;</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <Authors>$(Company)</Authors>
     <EmbedAllSources>true</EmbedAllSources>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Api.Rest/Api.Rest.csproj
+++ b/src/Api.Rest/Api.Rest.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet package specifications">
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb; .xml;</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder); .xml;</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <Authors>$(Company)</Authors>
     <EmbedAllSources>true</EmbedAllSources>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
- Update BUILDING.md and status badge in README.md
- Do not include .pdb files in the NuGet to reduce file size again (the same as before GitHub Actions, we do have a task for adding SourceLink later)
- Remove retry-rumber from version, since retry does not change source code, thus creating the same nuget
- Pushes to PR or force pushing creates a new workflow run, increrasing the run-number instead to ensure different versions