### PR TITLE
fix: attribute value returns null instead of string.empty for null ra…

### DIFF
--- a/src/Api.Contracts/Attribute.cs
+++ b/src/Api.Contracts/Attribute.cs
@@ -76,12 +76,16 @@ namespace Zeiss.PiWeb.Api.Contracts
 		/// <summary>
 		/// Returns the string parsed attribute value of this attribute.
 		/// </summary>
+		[CanBeNull]
 		public string Value
 		{
 			get
 			{
 				if( _Value != null )
 					return _Value;
+
+				if( RawValue is null )
+					return null;
 
 				if( RawValue is double doubleValue )
 					return doubleValue.ToString( "G17", CultureInfo.InvariantCulture );
@@ -176,11 +180,11 @@ namespace Zeiss.PiWeb.Api.Contracts
 		{
 			return RawValue switch
 			{
-				int value             => value,
-				short value           => value,
-				double value          => value,
-				string value          => ParseDoubleValue( value ),
-				_                     => ParseDoubleValue( _Value )
+				int value    => value,
+				short value  => value,
+				double value => value,
+				string value => ParseDoubleValue( value ),
+				_            => ParseDoubleValue( _Value )
 			};
 		}
 
@@ -212,11 +216,11 @@ namespace Zeiss.PiWeb.Api.Contracts
 		{
 			return RawValue switch
 			{
-				int value             => value,
-				short value           => value,
-				double value          => value % 1 == 0 ? (int)value : null,
-				string value          => ParseIntValue( value ),
-				_                     => ParseIntValue( _Value )
+				int value    => value,
+				short value  => value,
+				double value => value % 1 == 0 ? (int)value : null,
+				string value => ParseIntValue( value ),
+				_            => ParseIntValue( _Value )
 			};
 		}
 

--- a/src/Api.Rest.Dtos.Tests/Data/AttributeExtensionsTest.cs
+++ b/src/Api.Rest.Dtos.Tests/Data/AttributeExtensionsTest.cs
@@ -482,7 +482,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Tests.Data
 			// @formatter:off — disable formatter after this line
 
 			// value: null
-			yield return CreateTestCase( null,  null, null, "",    null, null,   "null" );
+			yield return CreateTestCase( null,  null, null, null,    null, null,   "null" );
 
 			// @formatter:on — enable formatter after this line
 		}

--- a/src/Api.Rest.Dtos.Tests/Data/AttributeTest.cs
+++ b/src/Api.Rest.Dtos.Tests/Data/AttributeTest.cs
@@ -43,7 +43,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Tests.Data
 			var attribute = new Attribute( 1, null );
 
 			// assert
-			Assert.That( attribute.Value, Is.EqualTo( string.Empty ) );
+			Assert.That( attribute.Value, Is.Null );
 			Assert.That( attribute.RawValue, Is.Null );
 		}
 
@@ -131,7 +131,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Tests.Data
 		[TestCase( " ", " ", true )]
 		[TestCase( "\t", "\t", true )]
 		[TestCase( "Hello World", "Hello World", true )]
-		[TestCase( null, "", true )]
+		[TestCase( null, "", false )]
 		[TestCase( null, " ", false )]
 		[TestCase( "", " ", false )]
 		[TestCase( "Hello World", "", false )]
@@ -724,7 +724,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Tests.Data
 
 		private static IEnumerable CreateValidRawValueTestCases()
 		{
-			yield return new TestCaseData( null, "" ) { TestName = "null" };
+			yield return new TestCaseData( null, null ) { TestName = "null" };
 			yield return new TestCaseData( "", "" ) { TestName = "empty string" };
 			yield return new TestCaseData( "foo", "foo" ) { TestName = "string value" };
 			yield return new TestCaseData( 2, "2" ) { TestName = "integer value" };
@@ -756,7 +756,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Tests.Data
 			// @formatter:off — disable formatter after this line
 
 			// value: null
-			yield return CreateTestCase( null,  null, null, "",    null, null,   "null" );
+			yield return CreateTestCase( null,  null, null, null,    null, null,   "null" );
 
 			// @formatter:on — enable formatter after this line
 		}

--- a/src/Api.Rest.Dtos/Data/CatalogEntryDto.cs
+++ b/src/Api.Rest.Dtos/Data/CatalogEntryDto.cs
@@ -88,7 +88,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 				if( sb.Length > 0 )
 					sb.Append( " - " );
 
-				if( attribute.Value.Trim().Length > 0 )
+				if( attribute.Value is not null && attribute.Value.Trim().Length > 0 )
 					sb.Append( Convert.ToString( GetTypedAttributeValue( attribute ), provider ) );
 
 				allSameEntries &= attribute.Value == _Attributes[ 0 ].Value;
@@ -100,6 +100,7 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 			return sb.ToString();
 		}
 
+		[CanBeNull]
 		private static object GetTypedAttributeValue( Attribute attribute )
 		{
 			if( attribute.RawValue != null )

--- a/src/Api.Rest.Dtos/JsonConverters/JsonAttributeConverter.cs
+++ b/src/Api.Rest.Dtos/JsonConverters/JsonAttributeConverter.cs
@@ -67,6 +67,9 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.JsonConverters
 #endif
 					attribute = new Attribute( key, value );
 					return true;
+				case JsonTokenType.Null:
+					attribute = new Attribute( key, null );
+					return true;
 			}
 
 			attribute = default;


### PR DESCRIPTION
The attribute value now returns null in case the raw value is null. This behavior is equivalent to our previous domain implementation.