### PR TITLE
fix: Lower version to fix problem in release action

### DIFF
--- a/src/Api.Definitions/Api.Definitions.csproj
+++ b/src/Api.Definitions/Api.Definitions.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Zeiss.PiWeb.Api.Definitions</RootNamespace>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageVersion>8.0.0</PackageVersion>
+    <PackageVersion>7.1.0</PackageVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
- release workflow automatically raises the version and commits the changes
- no changes to commit will lead to an error
- we simply lower one version to have at least one change when creating the release via workflow