### PR TITLE
Parallelize request execution when retrieving measurements

### DIFF
--- a/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
@@ -44,6 +44,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 
 		private ServiceInformationDto _LastValidServiceInformation;
 		private DataServiceFeatureMatrix _FeatureMatrix;
+		private readonly int _MaxRequestsInParallel;
 
 		#endregion
 
@@ -55,9 +56,12 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 		/// <param name="serverUri">The PiWeb Server uri, including port and instance</param>
 		/// <param name="maxUriLength">The uri length limit</param>
 		/// <param name="restClient">Custom implementation of RestClient</param>
-		public DataServiceRestClient( [NotNull] Uri serverUri, int maxUriLength = RestClientBase.DefaultMaxUriLength, RestClientBase restClient = null )
+		/// <param name="maxRequestsInParallel"> The maximum number of concurrent tasks enabled by a <see cref="T:System.Threading.Tasks.ParallelOptions" /> instance.</param>
+		public DataServiceRestClient( [NotNull] Uri serverUri, int maxUriLength = RestClientBase.DefaultMaxUriLength, RestClientBase restClient = null, int maxRequestsInParallel = 8 )
 			: base( restClient ?? new RestClient( serverUri, EndpointName, maxUriLength: maxUriLength, serializer: ObjectSerializer.SystemTextJson ) )
-		{ }
+		{
+			_MaxRequestsInParallel = maxRequestsInParallel;
+		}
 
 		#endregion
 
@@ -817,12 +821,35 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 				var parameterSets = RestClientHelper.SplitAndMergeParameters( ServiceLocation, requestPath, MaxUriLength, parameterName, filter.MeasurementUuids, parameterDefinitions );
 
 				//Execute requests in parallel
-				var requests = parameterSets
-					.Select( set => RequestBuilder.CreateGet( requestPath, set ) )
-					.Select( request => _RestClient.Request<IReadOnlyCollection<SimpleMeasurementDto>>( request, cancellationToken ) );
-				var result = await Task.WhenAll( requests ).ConfigureAwait( false );
+				var result = new List<SimpleMeasurementDto>();
 
-				return LimitAndSortResult( result.SelectMany( r => r ), filter, result.Length );
+#if NET6_0_OR_GREATER
+				await Parallel.ForEachAsync(
+					parameterSets,
+					new ParallelOptions { CancellationToken = cancellationToken, MaxDegreeOfParallelism = _MaxRequestsInParallel },
+					async ( parameterSet, token ) =>
+					{
+						var request = RequestBuilder.CreateGet( requestPath, parameterSet );
+						var measurements = await _RestClient.Request<IReadOnlyCollection<SimpleMeasurementDto>>( request, token ).ConfigureAwait( false );
+
+						lock( result )
+							result.AddRange( measurements );
+					} ).ConfigureAwait( false );
+#else
+				Parallel.ForEach(
+					parameterSets,
+					new ParallelOptions { CancellationToken = cancellationToken, MaxDegreeOfParallelism = _MaxRequestsInParallel },
+					parameterSet =>
+					{
+						var request = RequestBuilder.CreateGet( requestPath, parameterSet );
+						var measurements = _RestClient.Request<IReadOnlyCollection<SimpleMeasurementDto>>( request, cancellationToken ).ConfigureAwait( false ).GetAwaiter().GetResult();
+
+						lock( result )
+							result.AddRange( measurements );
+					} );
+#endif
+
+				return LimitAndSortResult( result, filter, result.Count );
 			}
 
 			// split multiple part uuids into chunks of uuids using multiple requests to avoid "Request-URI Too Long" exception
@@ -838,12 +865,35 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 				var parameterSets = RestClientHelper.SplitAndMergeParameters( ServiceLocation, requestPath, MaxUriLength, parameterName, filter.PartUuids, parameterDefinitions );
 
 				//Execute requests in parallel
-				var requests = parameterSets
-					.Select( set => RequestBuilder.CreateGet( requestPath, set ) )
-					.Select( request => _RestClient.Request<IReadOnlyList<SimpleMeasurementDto>>( request, cancellationToken ) );
-				var result = await Task.WhenAll( requests ).ConfigureAwait( false );
+				var result = new List<SimpleMeasurementDto>();
 
-				return LimitAndSortResult( result.SelectMany( r => r ), filter, result.Length );
+#if NET6_0_OR_GREATER
+				await Parallel.ForEachAsync(
+					parameterSets,
+					new ParallelOptions { CancellationToken = cancellationToken, MaxDegreeOfParallelism = _MaxRequestsInParallel },
+					async ( parameterSet, token ) =>
+					{
+						var request = RequestBuilder.CreateGet( requestPath, parameterSet );
+						var measurements = await _RestClient.Request<IReadOnlyCollection<SimpleMeasurementDto>>( request, token ).ConfigureAwait( false );
+
+						lock( result )
+							result.AddRange( measurements );
+					} ).ConfigureAwait( false );
+#else
+				Parallel.ForEach(
+					parameterSets,
+					new ParallelOptions { CancellationToken = cancellationToken, MaxDegreeOfParallelism = _MaxRequestsInParallel },
+					parameterSet =>
+					{
+						var request = RequestBuilder.CreateGet( requestPath, parameterSet );
+						var measurements = _RestClient.Request<IReadOnlyCollection<SimpleMeasurementDto>>( request, cancellationToken ).ConfigureAwait( false ).GetAwaiter().GetResult();
+
+						lock( result )
+							result.AddRange( measurements );
+					} );
+#endif
+
+				return LimitAndSortResult( result, filter, result.Count );
 			}
 
 			{


### PR DESCRIPTION
Get rid of Task.WhenAll() by parallelizing request execution when retrieving measurements