### PR TITLE
refactor: make case sensitivity optional in parse method

### DIFF
--- a/src/Api.Rest.Dtos/Data/MeasurementFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/MeasurementFilterAttributesDto.cs
@@ -101,7 +101,6 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 			string order,
 			string requestedMeasurementAttributes,
 			string searchCondition,
-			string caseSensitive,
 			string statistics,
 			string aggregation,
 			string fromModificationDate,
@@ -109,7 +108,8 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 			string mergeAttributes,
 			string mergeCondition,
 			string mergeMasterPart,
-			string limitResultPerPart = "-1" )
+			string limitResultPerPart = "-1",
+			string caseSensitive = null )
 		{
 			var items = new[]
 			{

--- a/src/Api.Rest.Dtos/Data/MeasurementValueFilterAttributesDto.cs
+++ b/src/Api.Rest.Dtos/Data/MeasurementValueFilterAttributesDto.cs
@@ -110,14 +110,14 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Data
 			string requestedMeasurementAttributes,
 			string requestedValueAttributes,
 			string searchCondition,
-			string caseSensitive,
 			string aggregation,
 			string fromModificationDate,
 			string toModificationDate,
 			string mergeAttributes,
 			string mergeCondition,
 			string mergeMasterPart,
-			string limitResultPerPart = "-1" )
+			string limitResultPerPart = "-1",
+			string caseSensitive = null )
 		{
 			var items = new[]
 			{


### PR DESCRIPTION
- case sensitivity is now optional in parse method of filter classes
- fixed line breaks