### PR TITLE
Fix comparison of double attributes

### DIFF
--- a/src/Api.Core/Attribute.cs
+++ b/src/Api.Core/Attribute.cs
@@ -354,10 +354,13 @@ namespace Zeiss.PiWeb.Api.Core
 			if( Key != other.Key )
 				return false;
 
-			if( RawValue is null || other.RawValue is null )
-				return Value == other.Value;
+			if( RawValue != null && other.RawValue != null )
+				return RawValueEquals( RawValue, other.RawValue );
 
-			return RawValueEquals( RawValue, other.RawValue );
+			if( RawValue is double || other.RawValue is double )
+				return Equals( RawValue ?? GetDoubleValue(), other.RawValue ?? other.GetDoubleValue() );
+
+			return Value == other.Value;
 		}
 
 		#endregion

--- a/src/Api.Rest.Dtos.Tests/Data/AttributeTest.cs
+++ b/src/Api.Rest.Dtos.Tests/Data/AttributeTest.cs
@@ -231,6 +231,63 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Tests.Data
 		}
 
 		[Test]
+		[TestCase( "1", 1, true )]
+		[TestCase( "1", 2, false )]
+		[TestCase( "0.1", 0.1, true )]
+		[TestCase( "0.1", 0.2, false )]
+		[TestCase( "-1", -1, true )]
+		[TestCase( "-1", -2, false )]
+		[TestCase( "-0.1", -0.1, true )]
+		[TestCase( "-0.1", -0.2, false )]
+		[TestCase( "-0.1", 0.1, false )]
+		[TestCase( "0.0", 0.0, true )]
+		[TestCase( "", 0.0, false )]
+		[TestCase( "foo", 0.0, false )]
+		public void Equals_LeftFromStringRightFromDouble_ReturnsCorrectResult( string x, double y, bool expectedResult )
+		{
+			// arrange
+			var attributeKey = Fixture.Create<ushort>();
+			var xAttribute = new Attribute( attributeKey, x );
+			var yAttribute = new Attribute( attributeKey, y );
+
+			// act, assert
+			Assert.That( Equals( xAttribute, yAttribute ), Is.EqualTo( expectedResult ) );
+
+			Assert.That( xAttribute == yAttribute, Is.EqualTo( expectedResult ) );
+			Assert.That( xAttribute != yAttribute, Is.Not.EqualTo( expectedResult ) );
+		}
+
+		[Test]
+		[TestCase( 1, "1", true )]
+		[TestCase( 1, "2", false )]
+		[TestCase( 0.1, "0.1", true )]
+		[TestCase( 0.1, "0.2", false )]
+		[TestCase( -1, "-1", true )]
+		[TestCase( -1, "-2", false )]
+		[TestCase( -0.1, "-0.1", true )]
+		[TestCase( -0.1, "-0.2", false )]
+		[TestCase( -0.1, "0.1", false )]
+		[TestCase( 0.0, "0.0", true )]
+		[TestCase( double.NaN, "1", false )]
+		[TestCase( double.PositiveInfinity, "1", false )]
+		[TestCase( double.NegativeInfinity, "1", false )]
+		[TestCase( 0.0, "", false )]
+		[TestCase( 0.0, "foo", false )]
+		public void Equals_LeftFromDoubleRightFromString_ReturnsCorrectResult( double x, string y, bool expectedResult )
+		{
+			// arrange
+			var attributeKey = Fixture.Create<ushort>();
+			var xAttribute = new Attribute( attributeKey, x );
+			var yAttribute = new Attribute( attributeKey, y );
+
+			// act, assert
+			Assert.That( Equals( xAttribute, yAttribute ), Is.EqualTo( expectedResult ) );
+
+			Assert.That( xAttribute == yAttribute, Is.EqualTo( expectedResult ) );
+			Assert.That( xAttribute != yAttribute, Is.Not.EqualTo( expectedResult ) );
+		}
+
+		[Test]
 		[TestCaseSource( nameof( CreateCompareDateTimeAttributesTestCases ) )]
 		public void Test_Compare_DateTime_Attributes( AttributeComparisonTestCase testCase )
 		{


### PR DESCRIPTION
This pull request improves the comparison of attributes in the situation one attribute was created from a string and the other from a double. The string attribute with a value of for example "0.1" is now parsed to double before comparison so that the transient value of 0.10000000000000001 is used in the equals method. Before the fix the string values had been compared (for example "0.1" with "0.10000000000000001") which had failed.