### PR TITLE
Improve creation of rest clients

### DIFF
--- a/src/Api.Rest/Common/Authentication/IAuthenticationHandler.cs
+++ b/src/Api.Rest/Common/Authentication/IAuthenticationHandler.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2016                             */
+/* (c) Carl Zeiss 2024                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion

--- a/src/Api.Rest/Common/Authentication/IAuthenticationHandler.cs
+++ b/src/Api.Rest/Common/Authentication/IAuthenticationHandler.cs
@@ -10,6 +10,8 @@
 
 namespace Zeiss.PiWeb.Api.Rest.Common.Authentication;
 
+using System.Threading.Tasks;
+
 /// <summary>
 /// Responsible for handling the authentication of a rest client.
 /// </summary>
@@ -27,14 +29,14 @@ public interface IAuthenticationHandler
 	/// This method is called before a rest request is send.
 	/// </summary>
 	/// <param name="context">Contains information and possible actions on current request and the rest client.</param>
-	public void HandleRequest( IRequestContext context );
+	public Task HandleRequest( IRequestContext context );
 
 	/// <summary>
 	/// This method is called after a rest response is received. To retry the request, set the RetryRequest property of the context to
 	/// <c>true</c>.
 	/// </summary>
 	/// <param name="context">Contains information and possible actions on current request, response and the rest client.</param>
-	public void HandleResponse( IResponseContext context );
+	public Task HandleResponse( IResponseContext context );
 
 	#endregion
 }

--- a/src/Api.Rest/Common/Authentication/IAuthenticationHandler.cs
+++ b/src/Api.Rest/Common/Authentication/IAuthenticationHandler.cs
@@ -1,0 +1,40 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2016                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Common.Authentication;
+
+/// <summary>
+/// Responsible for handling the authentication of a rest client.
+/// </summary>
+public interface IAuthenticationHandler
+{
+	#region methods
+
+	/// <summary>
+	/// This method is called when the authentication handler is set on a rest client.
+	/// </summary>
+	/// <param name="context">Contains information and possible actions on the rest client.</param>
+	public void InitializeRestClient( IInitializationContext context );
+
+	/// <summary>
+	/// This method is called before a rest request is send.
+	/// </summary>
+	/// <param name="context">Contains information and possible actions on current request and the rest client.</param>
+	public void HandleRequest( IRequestContext context );
+
+	/// <summary>
+	/// This method is called after a rest response is received. To retry the request, set the RetryRequest property of the context to
+	/// <c>true</c>.
+	/// </summary>
+	/// <param name="context">Contains information and possible actions on current request, response and the rest client.</param>
+	public void HandleResponse( IResponseContext context );
+
+	#endregion
+}

--- a/src/Api.Rest/Common/Authentication/IInitializationContext.cs
+++ b/src/Api.Rest/Common/Authentication/IInitializationContext.cs
@@ -1,0 +1,50 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2016                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Common.Authentication;
+
+#region usings
+
+using System;
+using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Client;
+
+#endregion
+
+/// <summary>
+/// Represents the context of a <see cref="IAuthenticationHandler.InitializeRestClient"/> call. Can be used to get information about the
+/// rest client. The context also provides actions that are available to modify the rest client.
+/// </summary>
+public interface IInitializationContext
+{
+	#region properties
+
+	/// <summary>
+	/// The current authentication container of the rest client.
+	/// </summary>
+	[NotNull] AuthenticationContainer CurrentAuthenticationContainer { get; }
+
+	/// <summary>
+	/// The service location of the rest client.
+	/// </summary>
+	[NotNull] Uri ServiceLocation { get; }
+
+	#endregion
+
+	#region methods
+
+	/// <summary>
+	/// Sets a new authentication container on the rest client.
+	/// </summary>
+	/// <param name="newAuthenticationContainer">The new authentication container to set.</param>
+	void UpdateAuthenticationContainer( [NotNull] AuthenticationContainer newAuthenticationContainer );
+
+	#endregion
+}

--- a/src/Api.Rest/Common/Authentication/IInitializationContext.cs
+++ b/src/Api.Rest/Common/Authentication/IInitializationContext.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2016                             */
+/* (c) Carl Zeiss 2024                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion

--- a/src/Api.Rest/Common/Authentication/IRequestContext.cs
+++ b/src/Api.Rest/Common/Authentication/IRequestContext.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2016                             */
+/* (c) Carl Zeiss 2024                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion

--- a/src/Api.Rest/Common/Authentication/IRequestContext.cs
+++ b/src/Api.Rest/Common/Authentication/IRequestContext.cs
@@ -1,0 +1,80 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2016                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Common.Authentication;
+
+#region usings
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Client;
+
+#endregion
+
+/// <summary>
+/// Represents the context of a <see cref="IAuthenticationHandler.HandleRequest"/> call. Can be used to get information about the current
+/// request. The context also provides actions that are available to modify the behavior of the request.
+/// </summary>
+public interface IRequestContext
+{
+	#region properties
+
+	/// <summary>
+	/// Identifies the current request session. This number will be different for each separate rest request but will be the same while
+	/// retrying a rest request. See <see cref="ResponseContext.RetryRequest"/>.
+	/// </summary>
+	long Session { get; }
+
+	/// <summary>
+	/// Identifies the current attempt to do a rest request. The original request will always be attempt 1. Every following retry will
+	/// increase this value by one. See <see cref="ResponseContext.RetryRequest"/>.
+	/// </summary>
+	long Attempt { get; }
+
+	/// <summary>
+	/// The current request.
+	/// </summary>
+	[NotNull] HttpRequestMessage CurrentRequest { get; }
+
+	/// <summary>
+	/// The current authentication container of the rest client used for the request.
+	/// </summary>
+	[NotNull] AuthenticationContainer CurrentAuthenticationContainer { get; }
+
+	/// <summary>
+	/// The service location of the rest client used for the request.
+	/// </summary>
+	[NotNull] Uri ServiceLocation { get; }
+
+	/// <summary>
+	/// Payload data carried over from the preceding response handler. This field is only set when this is a retry attempt.
+	/// See <see cref="Payload"/>.
+	/// </summary>
+	[CanBeNull] public object RetryPayload { get; }
+
+	/// <summary>
+	/// The cancellation token of the current operation.
+	/// </summary>
+	public CancellationToken CancellationToken { get; }
+
+	#endregion
+
+	#region methods
+
+	/// <summary>
+	/// Sets a new authentication container on the rest client used for the request.
+	/// </summary>
+	/// <param name="newAuthenticationContainer">The new authentication container to set.</param>
+	void UpdateAuthenticationContainer( [NotNull] AuthenticationContainer newAuthenticationContainer );
+
+	#endregion
+}

--- a/src/Api.Rest/Common/Authentication/IResponseContext.cs
+++ b/src/Api.Rest/Common/Authentication/IResponseContext.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2016                             */
+/* (c) Carl Zeiss 2024                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion

--- a/src/Api.Rest/Common/Authentication/IResponseContext.cs
+++ b/src/Api.Rest/Common/Authentication/IResponseContext.cs
@@ -1,0 +1,93 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2016                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Common.Authentication;
+
+#region usings
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Client;
+
+#endregion
+
+/// <summary>
+/// Represents the context of a <see cref="IAuthenticationHandler.HandleResponse"/> call. Can be used to get information about the current
+/// request and response. The context also provides actions that are available as reaction to the given response.
+/// </summary>
+public interface IResponseContext
+{
+	#region properties
+
+	/// <summary>
+	/// Identifies the current request session. This number will be different for each separate rest request but will be the same while
+	/// retrying a rest request. See <see cref="RetryRequest"/>.
+	/// </summary>
+	long Session { get; }
+
+	/// <summary>
+	/// Identifies the current attempt to do a rest request. The original request will always be attempt 1. Every following retry will
+	/// increase this value by one.
+	/// </summary>
+	long Attempt { get; }
+
+	/// <summary>
+	/// When set to true, the request will be retried after the authentication handler returns.<br/>
+	/// Note: Modifying <see cref="CurrentRequest"/> will have no effect on the retried request because a new request is build for each
+	/// retry attempt.
+	/// </summary>
+	bool RetryRequest { get; set; }
+
+	/// <summary>
+	/// Defines payload data that will be carried over to the next request attempt when <see cref="RetryRequest"/> is true.
+	/// See <see cref="IRequestContext.RetryPayload"/>.
+	/// </summary>
+	[CanBeNull] public object RetryPayload { get; set; }
+
+	/// <summary>
+	/// The current request.
+	/// </summary>
+	[NotNull] HttpRequestMessage CurrentRequest { get; }
+
+	/// <summary>
+	/// The current response.
+	/// </summary>
+	[NotNull] HttpResponseMessage CurrentResponse { get; }
+
+	/// <summary>
+	/// The current authentication container of the rest client used for the request.
+	/// </summary>
+	[NotNull] AuthenticationContainer CurrentAuthenticationContainer { get; }
+
+	/// <summary>
+	/// The service location of the rest client used for the request.
+	/// </summary>
+	[NotNull] Uri ServiceLocation { get; }
+
+	/// <summary>
+	/// The cancellation token of the current operation.
+	/// </summary>
+	public CancellationToken CancellationToken { get; }
+
+	#endregion
+
+	#region methods
+
+	/// <summary>
+	/// Sets a new authentication container on the rest client used for the request. Can be combined with
+	/// <see cref="newAuthenticationContainer"/> to modify authentication data of the retried request.
+	/// </summary>
+	/// <param name="newAuthenticationContainer">The new authentication container to set.</param>
+	void UpdateAuthenticationContainer( [NotNull] AuthenticationContainer newAuthenticationContainer );
+
+	#endregion
+}

--- a/src/Api.Rest/Common/Authentication/InitializationContext.cs
+++ b/src/Api.Rest/Common/Authentication/InitializationContext.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2016                             */
+/* (c) Carl Zeiss 2024                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion

--- a/src/Api.Rest/Common/Authentication/InitializationContext.cs
+++ b/src/Api.Rest/Common/Authentication/InitializationContext.cs
@@ -1,0 +1,61 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2016                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Common.Authentication;
+
+#region usings
+
+using System;
+using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Client;
+
+#endregion
+
+/// <inheritdoc />
+internal class InitializationContext : IInitializationContext
+{
+	#region members
+
+	[NotNull] private readonly RestClientBase _RestClient;
+
+	#endregion
+
+	#region constructors
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="InitializationContext"/> class.
+	/// </summary>
+	/// <param name="restClient">The rest client.</param>
+	public InitializationContext( [NotNull] RestClientBase restClient )
+	{
+		_RestClient = restClient ?? throw new ArgumentNullException( nameof( restClient ) );
+	}
+
+	#endregion
+
+	#region interface IResponseContext
+
+	/// <inheritdoc />
+	[NotNull]
+	public AuthenticationContainer CurrentAuthenticationContainer => _RestClient.AuthenticationContainer;
+
+	/// <inheritdoc />
+	[NotNull]
+	public Uri ServiceLocation => _RestClient.ServiceLocation;
+
+	/// <inheritdoc />
+	public void UpdateAuthenticationContainer( [NotNull] AuthenticationContainer newAuthenticationContainer )
+	{
+		_RestClient.AuthenticationContainer =
+			newAuthenticationContainer ?? throw new ArgumentNullException( nameof( newAuthenticationContainer ) );
+	}
+
+	#endregion
+}

--- a/src/Api.Rest/Common/Authentication/NonInteractiveAuthenticationHandler.cs
+++ b/src/Api.Rest/Common/Authentication/NonInteractiveAuthenticationHandler.cs
@@ -1,0 +1,304 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2016                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Common.Authentication;
+
+#region usings
+
+using System;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Client;
+using Zeiss.PiWeb.Api.Rest.Common.Utilities;
+
+#endregion
+
+/// <summary>
+/// A processor method that executes a given refresh token consumer on an internally stored OIDC refresh token. The consumer returns
+/// a new refresh token that then replaces the internally stored refresh token for any future calls. If the input refresh token of the
+/// consumer can be reused again after this operation, the consumer may return this input token instead of a new token.
+/// If no internally stored refresh token is available, the consumer is not executed at all.
+/// The return value of this processor indicates whether the consumer was executed (<c>true</c>), or not executed (<c>false</c>).
+/// Using a processor instead of a static refresh token enables refresh token rotation.
+/// </summary>
+public delegate Task<bool> RefreshTokenProcessorAsync( Func<string, Task<string>> consumer, CancellationToken token );
+
+/// <summary>
+/// <inheritdoc />
+/// This authentication handler allows authentication via statically predefined authentication data and avoids any user interaction.
+/// In case of OpenIDC authentication a static refresh token must be given that can be used to derive an access token when necessary.
+/// </summary>
+public class NonInteractiveAuthenticationHandler : IAuthenticationHandler
+{
+	#region members
+
+	private static readonly SemaphoreSlim LoginRefreshSemaphore = new(1, 1);
+
+	#endregion
+
+	#region constructors
+
+	private NonInteractiveAuthenticationHandler(
+		AuthenticationMode authenticationMode,
+		[CanBeNull] string username = null,
+		[CanBeNull] string password = null,
+		[CanBeNull] X509Certificate2 clientCertificate = null,
+		[CanBeNull] RefreshTokenProcessorAsync refreshTokenProcessor = null )
+	{
+		AuthenticationMode = authenticationMode;
+		Username = username;
+		Password = password;
+		ClientCertificate = clientCertificate;
+		RefreshTokenProcessor = refreshTokenProcessor;
+	}
+
+	#endregion
+
+	#region properties
+
+	/// <summary>
+	/// The authentication mode.
+	/// </summary>
+	public AuthenticationMode AuthenticationMode { get; }
+
+	/// <summary>
+	/// The username used for authentication. Only used when <see cref="AuthenticationMode"/> is either
+	/// <see cref="AuthenticationMode.NoneOrBasic"/> or <see cref="AuthenticationMode.Windows"/>.
+	/// </summary>
+	[CanBeNull]
+	public string Username { get; }
+
+	/// <summary>
+	/// The password used for authentication. Only used when <see cref="AuthenticationMode"/> is either
+	/// <see cref="AuthenticationMode.NoneOrBasic"/> or <see cref="AuthenticationMode.Windows"/>.
+	/// </summary>
+	[CanBeNull]
+	private string Password { get; }
+
+	[CanBeNull]
+	private X509Certificate2 ClientCertificate { get; }
+
+	[CanBeNull]
+	private RefreshTokenProcessorAsync RefreshTokenProcessor { get; }
+
+	#endregion
+
+	#region methods
+
+	[CanBeNull]
+	private static X509Certificate2 FindCertificate( string certificateThumbprint )
+	{
+		if( string.IsNullOrEmpty( certificateThumbprint ) )
+			return null;
+
+		return CertificateHelper.FindCertificateByThumbprint( certificateThumbprint, storeLocation: StoreLocation.CurrentUser )
+				?? CertificateHelper.FindCertificateByThumbprint( certificateThumbprint, storeLocation: StoreLocation.LocalMachine );
+	}
+
+	#endregion
+
+	#region interface IAuthenticationHandler
+
+	/// <inheritdoc />
+	public void InitializeRestClient( IInitializationContext context )
+	{
+		switch( AuthenticationMode )
+		{
+			case AuthenticationMode.NoneOrBasic when Username != null:
+				context.UpdateAuthenticationContainer(
+					AuthenticationContainer.FromUsernamePasswordCredential(
+						new UsernamePasswordCredential( Username, Password ?? string.Empty ) ) );
+				break;
+
+			case AuthenticationMode.Windows when Username != null:
+				context.UpdateAuthenticationContainer(
+					new AuthenticationContainer(
+						AuthenticationMode.Windows,
+						new NetworkCredential( Username, Password ?? string.Empty ) ) );
+				break;
+
+			case AuthenticationMode.Windows:
+				context.UpdateAuthenticationContainer( new AuthenticationContainer( AuthenticationMode.Windows ) );
+				break;
+
+			case AuthenticationMode.HardwareCertificate:
+			case AuthenticationMode.Certificate:
+				context.UpdateAuthenticationContainer(
+					AuthenticationContainer.FromCertificateCredential(
+						CertificateCredential.CreateFromCertificate( ClientCertificate ) ) );
+				break;
+
+			case AuthenticationMode.OAuth:
+				context.UpdateAuthenticationContainer( new AuthenticationContainer( AuthenticationMode.OAuth ) );
+				break;
+
+			default:
+				context.UpdateAuthenticationContainer( new AuthenticationContainer( AuthenticationMode.NoneOrBasic ) );
+				break;
+
+			// NonInteractiveAuthenticationHandler.Certificate( Certificate );
+		}
+	}
+
+	/// <inheritdoc />
+	public Task HandleRequest( IRequestContext context )
+	{
+		return Task.CompletedTask;
+	}
+
+	/// <inheritdoc />
+	public async Task HandleResponse( IResponseContext context )
+	{
+		// Since we are non-interactive, the only authentication error we can meaningfully handle is an expired OIDC access token.
+		// If this is indeed the case, we can try to get a new access token for our known refresh token. If the new access token
+		// does not work either, we can only give up.
+
+		var isOAuth = context.CurrentAuthenticationContainer.Mode == AuthenticationMode.OAuth;
+		var isUnauthorized = context.CurrentResponse.StatusCode == HttpStatusCode.Unauthorized;
+		if( !isUnauthorized || !isOAuth || RefreshTokenProcessor == null || context.Attempt > 1 )
+			return;
+
+		await LoginRefreshSemaphore.WaitAsync( context.CancellationToken ).ConfigureAwait( false );
+
+		try
+		{
+			var instanceUri = new Uri( context.ServiceLocation, "../" );
+			OAuthTokenCredential credential = null;
+			await RefreshTokenProcessor(
+				async ( currentRefreshToken ) =>
+				{
+					credential = await OAuthHelper.GetAuthenticationInformationForDatabaseUrlAsync(
+						instanceUri.AbsoluteUri,
+						currentRefreshToken,
+						bypassLocalCache: true ).ConfigureAwait( false );
+
+					return credential?.RefreshToken ?? currentRefreshToken;
+				},
+				context.CancellationToken ).ConfigureAwait( false );
+
+			if( credential == null )
+				return;
+
+			var newContainer = AuthenticationContainer.FromOAuthTokenCredential( credential );
+			if( newContainer == context.CurrentAuthenticationContainer )
+				return;
+
+			context.UpdateAuthenticationContainer( newContainer );
+			context.RetryRequest = true;
+		}
+		finally
+		{
+			LoginRefreshSemaphore.Release();
+		}
+	}
+
+	/// <summary>
+	/// Creates a new <see cref="NonInteractiveAuthenticationHandler"/> instance which uses a given refresh token to implement a
+	/// non-interactive OIDC authentication.
+	/// </summary>
+	/// <param name="refreshToken">The refresh token to use to fetch access token.</param>
+	/// <returns>The new instance.</returns>
+	public static NonInteractiveAuthenticationHandler OIDC( string refreshToken )
+	{
+		return new NonInteractiveAuthenticationHandler(
+			AuthenticationMode.OAuth,
+			refreshTokenProcessor: async ( consumer, _ ) =>
+			{
+				await consumer( refreshToken ).ConfigureAwait( false );
+				return true;
+			} );
+	}
+
+	/// <summary>
+	/// Creates a new <see cref="NonInteractiveAuthenticationHandler"/> instance which uses a given refresh token processor method to
+	/// implement a non-interactive OIDC authentication with refresh token rotation.
+	/// Each time a new access token is required, the given processor is called with a predefined consumer method. The given processor
+	/// method must execute the refresh token consumer on an internally stored OIDC refresh token. The consumer returns
+	/// a new refresh token that must then replace the internally stored refresh token for any future calls. If the input refresh token of
+	/// the consumer can be reused again after this operation, the consumer may return this input refresh token instead of a new token.
+	/// If no internally stored refresh token is available for any reason, the processor method should not execute the consumer at all.
+	/// The return value of the processor must indicate whether the consumer was executed (<c>true</c>), or not executed (<c>false</c>).
+	/// Using a processor instead of a static refresh token enables refresh token rotation.
+	/// </summary>
+	/// <param name="refreshTokenProcessor">A method to process and potentially rotate the existing refresh token.</param>
+	/// <returns>The new instance.</returns>
+	public static NonInteractiveAuthenticationHandler OIDC( RefreshTokenProcessorAsync refreshTokenProcessor )
+	{
+		return new NonInteractiveAuthenticationHandler(
+			AuthenticationMode.OAuth,
+			refreshTokenProcessor: refreshTokenProcessor );
+	}
+
+	/// <summary>
+	/// Creates a new <see cref="NonInteractiveAuthenticationHandler"/> instance which implements Single Sign-on authentication based
+	/// on Kerberos or NTLM authentication.
+	/// </summary>
+	/// <returns>The new instance.</returns>
+	public static NonInteractiveAuthenticationHandler WindowsSSO()
+	{
+		return new NonInteractiveAuthenticationHandler( AuthenticationMode.Windows );
+	}
+
+	/// <summary>
+	/// Creates a new <see cref="NonInteractiveAuthenticationHandler"/> instance which implements username/password authentication based
+	/// on Kerberos or NTLM authentication.
+	/// </summary>
+	/// <param name="username">The username.</param>
+	/// <param name="password">The password.</param>
+	/// <returns>The new instance.</returns>
+	public static NonInteractiveAuthenticationHandler Windows( string username, string password )
+	{
+		return new NonInteractiveAuthenticationHandler( AuthenticationMode.Windows, username, password );
+	}
+
+	/// <summary>
+	/// Creates a new <see cref="NonInteractiveAuthenticationHandler"/> instance which implements username/password authentication based
+	/// on Basic authentication.
+	/// </summary>
+	/// <param name="username">The username.</param>
+	/// <param name="password">The password.</param>
+	/// <returns>The new instance.</returns>
+	public static NonInteractiveAuthenticationHandler Basic( string username, string password )
+	{
+		return new NonInteractiveAuthenticationHandler( AuthenticationMode.NoneOrBasic, username, password );
+	}
+
+	/// <summary>
+	/// Creates a new <see cref="NonInteractiveAuthenticationHandler"/> instance which implements certificate authentication based
+	/// on https client certificates.
+	/// </summary>
+	/// <param name="certificate">The certificate.</param>
+	/// <returns>The new instance.</returns>
+	public static NonInteractiveAuthenticationHandler Certificate( X509Certificate2 certificate )
+	{
+		return new NonInteractiveAuthenticationHandler( AuthenticationMode.Certificate, clientCertificate: certificate );
+	}
+
+	/// <summary>
+	/// Creates a new <see cref="NonInteractiveAuthenticationHandler"/> instance which implements certificate authentication based
+	/// on https client certificates.
+	/// </summary>
+	/// <param name="certificateThumbprint">
+	/// The thumbprint of the certificate to use. The certificate will be looked up in the local certificate storage of the current
+	/// user first and additionally in the local computer storage if it is not found in the local user storage.
+	/// If no certificate is found, no certificate will be send to the server when connecting.
+	/// </param>
+	/// <returns>The new instance.</returns>
+	public static NonInteractiveAuthenticationHandler Certificate( string certificateThumbprint )
+	{
+		var certificate = FindCertificate( certificateThumbprint );
+		return new NonInteractiveAuthenticationHandler( AuthenticationMode.Certificate, clientCertificate: certificate );
+	}
+
+	#endregion
+}

--- a/src/Api.Rest/Common/Authentication/NonInteractiveAuthenticationHandler.cs
+++ b/src/Api.Rest/Common/Authentication/NonInteractiveAuthenticationHandler.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2016                             */
+/* (c) Carl Zeiss 2024                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion
@@ -145,8 +145,6 @@ public class NonInteractiveAuthenticationHandler : IAuthenticationHandler
 			default:
 				context.UpdateAuthenticationContainer( new AuthenticationContainer( AuthenticationMode.NoneOrBasic ) );
 				break;
-
-			// NonInteractiveAuthenticationHandler.Certificate( Certificate );
 		}
 	}
 
@@ -274,8 +272,8 @@ public class NonInteractiveAuthenticationHandler : IAuthenticationHandler
 	}
 
 	/// <summary>
-	/// Creates a new <see cref="NonInteractiveAuthenticationHandler"/> instance which implements certificate authentication based
-	/// on https client certificates.
+	/// Creates a new <see cref="NonInteractiveAuthenticationHandler"/> instance which implements authentication based
+	/// on a client certificate.
 	/// </summary>
 	/// <param name="certificate">The certificate.</param>
 	/// <returns>The new instance.</returns>
@@ -285,8 +283,8 @@ public class NonInteractiveAuthenticationHandler : IAuthenticationHandler
 	}
 
 	/// <summary>
-	/// Creates a new <see cref="NonInteractiveAuthenticationHandler"/> instance which implements certificate authentication based
-	/// on https client certificates.
+	/// Creates a new <see cref="NonInteractiveAuthenticationHandler"/> instance which implements authentication based
+	/// on a client certificate.
 	/// </summary>
 	/// <param name="certificateThumbprint">
 	/// The thumbprint of the certificate to use. The certificate will be looked up in the local certificate storage of the current

--- a/src/Api.Rest/Common/Authentication/RequestContext.cs
+++ b/src/Api.Rest/Common/Authentication/RequestContext.cs
@@ -1,0 +1,97 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2016                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Common.Authentication;
+
+#region usings
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Client;
+
+#endregion
+
+/// <inheritdoc />
+internal class RequestContext : IRequestContext
+{
+	#region members
+
+	[NotNull] private readonly RestClientBase _RestClient;
+
+	#endregion
+
+	#region constructors
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="RequestContext"/> class.
+	/// </summary>
+	/// <param name="restClient">The rest client used to make the rest request.</param>
+	/// <param name="request">The rest request.</param>
+	/// <param name="session">Identifies the current request session.</param>
+	/// <param name="attempt">The current request attempt.</param>
+	/// <param name="retryPayload">The payload carried over from the previous attempt.</param>
+	/// <param name="cancellationToken">The cancellation token of the operation.</param>
+	public RequestContext(
+		[NotNull] RestClientBase restClient,
+		[NotNull] HttpRequestMessage request,
+		long session,
+		long attempt,
+		[CanBeNull] object retryPayload,
+		CancellationToken cancellationToken)
+	{
+		_RestClient = restClient ?? throw new ArgumentNullException( nameof( restClient ) );
+
+		Session = session;
+		Attempt = attempt;
+		CurrentRequest = request ?? throw new ArgumentNullException( nameof( request ) );
+		RetryPayload = retryPayload;
+		CancellationToken = cancellationToken;
+	}
+
+	#endregion
+
+	#region interface IResponseContext
+
+	/// <inheritdoc />
+	public long Session { get; }
+
+	/// <inheritdoc />
+	public long Attempt { get; }
+
+	/// <inheritdoc />
+	[NotNull]
+	public HttpRequestMessage CurrentRequest { get; }
+
+	/// <inheritdoc />
+	[NotNull]
+	public AuthenticationContainer CurrentAuthenticationContainer => _RestClient.AuthenticationContainer;
+
+	/// <inheritdoc />
+	[NotNull]
+	public Uri ServiceLocation => _RestClient.ServiceLocation;
+
+	/// <inheritdoc />
+	[CanBeNull]
+	public object RetryPayload { get; }
+
+	/// <inheritdoc />
+	public CancellationToken CancellationToken { get; }
+
+	/// <inheritdoc />
+	public void UpdateAuthenticationContainer( [NotNull] AuthenticationContainer newAuthenticationContainer )
+	{
+		_RestClient.AuthenticationContainer =
+			newAuthenticationContainer ?? throw new ArgumentNullException( nameof( newAuthenticationContainer ) );
+	}
+
+	#endregion
+}

--- a/src/Api.Rest/Common/Authentication/RequestContext.cs
+++ b/src/Api.Rest/Common/Authentication/RequestContext.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2016                             */
+/* (c) Carl Zeiss 2024                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion
@@ -68,26 +68,22 @@ internal class RequestContext : IRequestContext
 	public long Attempt { get; }
 
 	/// <inheritdoc />
-	[NotNull]
 	public HttpRequestMessage CurrentRequest { get; }
 
 	/// <inheritdoc />
-	[NotNull]
 	public AuthenticationContainer CurrentAuthenticationContainer => _RestClient.AuthenticationContainer;
 
 	/// <inheritdoc />
-	[NotNull]
 	public Uri ServiceLocation => _RestClient.ServiceLocation;
 
 	/// <inheritdoc />
-	[CanBeNull]
 	public object RetryPayload { get; }
 
 	/// <inheritdoc />
 	public CancellationToken CancellationToken { get; }
 
 	/// <inheritdoc />
-	public void UpdateAuthenticationContainer( [NotNull] AuthenticationContainer newAuthenticationContainer )
+	public void UpdateAuthenticationContainer( AuthenticationContainer newAuthenticationContainer )
 	{
 		_RestClient.AuthenticationContainer =
 			newAuthenticationContainer ?? throw new ArgumentNullException( nameof( newAuthenticationContainer ) );

--- a/src/Api.Rest/Common/Authentication/ResponseContext.cs
+++ b/src/Api.Rest/Common/Authentication/ResponseContext.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2016                             */
+/* (c) Carl Zeiss 2024                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion
@@ -71,18 +71,15 @@ internal class ResponseContext : IResponseContext
 	public bool RetryRequest { get; set; }
 
 	/// <inheritdoc />
-	[CanBeNull] public object RetryPayload { get; set; }
+	public object RetryPayload { get; set; }
 
 	/// <inheritdoc />
-	[NotNull]
 	public HttpRequestMessage CurrentRequest { get; }
 
 	/// <inheritdoc />
-	[NotNull]
 	public HttpResponseMessage CurrentResponse { get; }
 
 	/// <inheritdoc />
-	[NotNull]
 	public AuthenticationContainer CurrentAuthenticationContainer => _RestClient.AuthenticationContainer;
 
 	/// <inheritdoc />
@@ -92,7 +89,7 @@ internal class ResponseContext : IResponseContext
 	public CancellationToken CancellationToken { get; }
 
 	/// <inheritdoc />
-	public void UpdateAuthenticationContainer( [NotNull] AuthenticationContainer newAuthenticationContainer )
+	public void UpdateAuthenticationContainer( AuthenticationContainer newAuthenticationContainer )
 	{
 		_RestClient.AuthenticationContainer =
 			newAuthenticationContainer ?? throw new ArgumentNullException( nameof( newAuthenticationContainer ) );

--- a/src/Api.Rest/Common/Authentication/ResponseContext.cs
+++ b/src/Api.Rest/Common/Authentication/ResponseContext.cs
@@ -1,0 +1,102 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2016                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Common.Authentication;
+
+#region usings
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Client;
+
+#endregion
+
+/// <inheritdoc />
+internal class ResponseContext : IResponseContext
+{
+	#region members
+
+	[NotNull] private readonly RestClientBase _RestClient;
+
+	#endregion
+
+	#region constructors
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ResponseContext"/> class.
+	/// </summary>
+	/// <param name="restClient">The rest client used to make the rest request.</param>
+	/// <param name="request">The rest request.</param>
+	/// <param name="response">The rest response.</param>
+	/// <param name="session">Identifies the current request session.</param>
+	/// <param name="attempt">The current request attempt.</param>
+	/// <param name="cancellationToken">The cancellation token of the operation.</param>
+	public ResponseContext(
+		[NotNull] RestClientBase restClient,
+		[NotNull] HttpRequestMessage request,
+		[NotNull] HttpResponseMessage response,
+		long session,
+		long attempt,
+		CancellationToken cancellationToken)
+	{
+		_RestClient = restClient ?? throw new ArgumentNullException( nameof( restClient ) );
+
+		Session = session;
+		Attempt = attempt;
+		CancellationToken = cancellationToken;
+		CurrentRequest = request ?? throw new ArgumentNullException( nameof( request ) );
+		CurrentResponse = response ?? throw new ArgumentNullException( nameof( response ) );
+	}
+
+	#endregion
+
+	#region interface IResponseContext
+
+	/// <inheritdoc />
+	public long Session { get; }
+
+	/// <inheritdoc />
+	public long Attempt { get; }
+
+	/// <inheritdoc />
+	public bool RetryRequest { get; set; }
+
+	/// <inheritdoc />
+	[CanBeNull] public object RetryPayload { get; set; }
+
+	/// <inheritdoc />
+	[NotNull]
+	public HttpRequestMessage CurrentRequest { get; }
+
+	/// <inheritdoc />
+	[NotNull]
+	public HttpResponseMessage CurrentResponse { get; }
+
+	/// <inheritdoc />
+	[NotNull]
+	public AuthenticationContainer CurrentAuthenticationContainer => _RestClient.AuthenticationContainer;
+
+	/// <inheritdoc />
+	public Uri ServiceLocation => _RestClient.ServiceLocation;
+
+	/// <inheritdoc />
+	public CancellationToken CancellationToken { get; }
+
+	/// <inheritdoc />
+	public void UpdateAuthenticationContainer( [NotNull] AuthenticationContainer newAuthenticationContainer )
+	{
+		_RestClient.AuthenticationContainer =
+			newAuthenticationContainer ?? throw new ArgumentNullException( nameof( newAuthenticationContainer ) );
+	}
+
+	#endregion
+}

--- a/src/Api.Rest/Common/Client/RestClient.cs
+++ b/src/Api.Rest/Common/Client/RestClient.cs
@@ -15,6 +15,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 
 	using System;
 	using JetBrains.Annotations;
+	using Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
 
 	#endregion
 
@@ -31,6 +32,15 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 		/// <exception cref="ArgumentNullException"><paramref name="serverUri"/> is <see langword="null" />.</exception>
 		public RestClient( [NotNull] Uri serverUri, string endpointName, TimeSpan? timeout = null, int maxUriLength = DefaultMaxUriLength, bool chunked = true, [CanBeNull] IObjectSerializer serializer = null )
 			: base( serverUri, endpointName, timeout, maxUriLength, chunked, serializer: serializer )
+		{ }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RestClient" /> class.
+		/// </summary>
+		/// <exception cref="ArgumentNullException"><paramref name="endpointName"/> is <see langword="null" />.</exception>
+		/// <exception cref="ArgumentNullException"><paramref name="settings"/> is <see langword="null" />.</exception>
+		internal RestClient( [NotNull] string endpointName, [NotNull] RestClientSettings settings )
+			: base( endpointName, settings )
 		{ }
 
 		#endregion

--- a/src/Api.Rest/Common/Client/RestClientBase.cs
+++ b/src/Api.Rest/Common/Client/RestClientBase.cs
@@ -33,6 +33,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 	using CacheCow.Common;
 	using JetBrains.Annotations;
 	using Zeiss.PiWeb.Api.Rest.Common.Authentication;
+	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Common.Data;
 	using Zeiss.PiWeb.Api.Rest.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;
@@ -40,7 +41,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 
 	#endregion
 
-	public abstract class RestClientBase : IDisposable
+	public abstract class RestClientBase : IDisposable, ICustomRestClient
 	{
 		#region constants
 

--- a/src/Api.Rest/Common/Client/RestClientBase.cs
+++ b/src/Api.Rest/Common/Client/RestClientBase.cs
@@ -33,7 +33,6 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 	using CacheCow.Common;
 	using JetBrains.Annotations;
 	using Zeiss.PiWeb.Api.Rest.Common.Authentication;
-	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Common.Data;
 	using Zeiss.PiWeb.Api.Rest.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;

--- a/src/Api.Rest/Common/Client/RestClientBase.cs
+++ b/src/Api.Rest/Common/Client/RestClientBase.cs
@@ -494,8 +494,11 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 					request = requestCreationHandler();
 					SetDefaultHttpHeaders( request );
 
-					var requestContext = new RequestContext( this, request, currentSession, attempt, retryPayload, cancellationToken );
-					_AuthenticationHandler?.HandleRequest( requestContext );
+					if( _AuthenticationHandler != null )
+					{
+						var requestContext = new RequestContext( this, request, currentSession, attempt, retryPayload, cancellationToken );
+						await _AuthenticationHandler.HandleRequest( requestContext ).ConfigureAwait( false );
+					}
 
 					response = await _HttpClient.SendAsync( request, completionOptions, cancellationToken ).ConfigureAwait( false );
 
@@ -512,7 +515,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 					if( _AuthenticationHandler != null )
 					{
 						var context = new ResponseContext( this, request, response, currentSession, attempt, cancellationToken );
-						_AuthenticationHandler.HandleResponse( context );
+						await _AuthenticationHandler.HandleResponse( context ).ConfigureAwait( false );
 						if( context.RetryRequest )
 						{
 							response.Dispose();

--- a/src/Api.Rest/Contracts/ICustomRestClient.cs
+++ b/src/Api.Rest/Contracts/ICustomRestClient.cs
@@ -1,4 +1,10 @@
-namespace Zeiss.PiWeb.Api.Rest.Common.Contracts;
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss IMT (IZM Dresden)                    */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+namespace Zeiss.PiWeb.Api.Rest.Contracts;
 
 #region usings
 
@@ -11,12 +17,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Zeiss.PiWeb.Api.Rest.Common.Client;
-using Zeiss.PiWeb.Api.Rest.Contracts;
 
 #endregion
 
 /// <summary>
-/// Represent a custom rest client that can be used to execute rest request created by an request builder.
+/// Represent a custom rest client that can be used to execute generic rest requests created by a request builder.
 /// </summary>
 public interface ICustomRestClient
 {

--- a/src/Api.Rest/Contracts/ICustomRestClient.cs
+++ b/src/Api.Rest/Contracts/ICustomRestClient.cs
@@ -1,0 +1,55 @@
+namespace Zeiss.PiWeb.Api.Rest.Common.Contracts;
+
+#region usings
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Client;
+using Zeiss.PiWeb.Api.Rest.Contracts;
+
+#endregion
+
+/// <summary>
+/// Represent a custom rest client that can be used to execute rest request created by an request builder.
+/// </summary>
+public interface ICustomRestClient
+{
+	#region methods
+
+	Task Request( [NotNull] Func<HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+	Task Request( [NotNull] Func<IObjectSerializer, CancellationToken, HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+	Task<T> Request<T>( [NotNull] Func<HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+	Task<T> Request<T>( [NotNull] Func<IObjectSerializer, CancellationToken, HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+	Task<Stream> RequestStream( [NotNull] Func<HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+	Task<Stream> RequestStream( [NotNull] Func<IObjectSerializer, CancellationToken, HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+	IAsyncEnumerable<T> RequestEnumerated<T>( [NotNull] Func<HttpRequestMessage> requestCreationHandler, [EnumeratorCancellation] CancellationToken cancellationToken );
+	IAsyncEnumerable<T> RequestEnumerated<T>( [NotNull] Func<IObjectSerializer, CancellationToken, HttpRequestMessage> requestCreationHandler, [EnumeratorCancellation] CancellationToken cancellationToken );
+	Task<byte[]> RequestBytes( [NotNull] Func<HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+	Task<byte[]> RequestBytes( [NotNull] Func<IObjectSerializer, CancellationToken, HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+	Task<T> RequestBinary<T>( [NotNull] Func<HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+	Task<T> RequestBinary<T>( [NotNull] Func<IObjectSerializer, CancellationToken, HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+
+	/// <summary>
+	/// Start an async operation. Returns an URL to poll for status updates if the operation is accepted, otherwise the operation is done synchronously.
+	/// </summary>
+	/// <returns>Returns a Task that represents the duration of the initial REST request. The result of the task contains
+	/// the URI for polling the operation result or null in case the server already finished the request synchronously.</returns>
+	/// <exception cref="RestClientException">The response indicated status Accepted, but did not contain polling information.</exception>
+	Task<Uri> RequestAsyncOperation( [NotNull] Func<HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+
+	/// <summary>
+	/// Start an async operation. Returns an URL to poll for status updates if the operation is accepted, otherwise the operation is done synchronously.
+	/// </summary>
+	/// <returns>Returns a Task that represents the duration of the initial REST request. The result of the task contains
+	/// the URI for polling the operation result or null in case the server already finished the request synchronously.</returns>
+	/// <exception cref="RestClientException">The response indicated status Accepted, but did not contain polling information.</exception>
+	Task<Uri> RequestAsyncOperation( [NotNull] Func<IObjectSerializer, HttpRequestMessage> requestCreationHandler, CancellationToken cancellationToken );
+
+	#endregion
+}

--- a/src/Api.Rest/Contracts/IDataServiceRestClientBase.cs
+++ b/src/Api.Rest/Contracts/IDataServiceRestClientBase.cs
@@ -18,6 +18,7 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
 	using Zeiss.PiWeb.Api.Core;
+	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;
 	using Zeiss.PiWeb.Api.Rest.Dtos.Data;
 
@@ -28,6 +29,15 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 	/// </summary>
 	public interface IDataServiceRestClientBase<T> where T : DataServiceFeatureMatrix
 	{
+		#region properties
+
+		/// <summary>
+		/// A custom rest client that can be used to execute rest request created by a rest request builder.
+		/// </summary>
+		public ICustomRestClient CustomRestClient { get; }
+
+		#endregion
+
 		#region methods
 
 		/// <summary>
@@ -43,7 +53,22 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
 		Task<InterfaceVersionRange> GetInterfaceInformation( CancellationToken cancellationToken = default );
 
+		/// <summary>
+		/// Returns a <see cref="DataServiceFeatureMatrix"/> that describes features and abilities of the server for the data service
+		/// endpoint.
+		/// </summary>
+		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
 		Task<T> GetFeatureMatrix( CancellationToken cancellationToken = default );
+
+		/// <summary>
+		/// Returns a <see cref="DataServiceFeatureMatrix"/> that describes features and abilities of the server for the data service
+		/// endpoint.
+		/// </summary>
+		/// <param name="refreshPolicy">
+		/// Specifies if a previous result can be returned or if the server should be queried again requiring at least one rest request.
+		/// </param>
+		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+		Task<T> GetFeatureMatrix( RefreshPolicy refreshPolicy, CancellationToken cancellationToken = default );
 
 		/// <summary>
 		/// Method for fetching the <see cref="ConfigurationDto"/>. The <see cref="ConfigurationDto"/> contains the

--- a/src/Api.Rest/Contracts/IDataServiceRestClientBase.cs
+++ b/src/Api.Rest/Contracts/IDataServiceRestClientBase.cs
@@ -18,7 +18,6 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
 	using Zeiss.PiWeb.Api.Core;
-	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;
 	using Zeiss.PiWeb.Api.Rest.Dtos.Data;
 

--- a/src/Api.Rest/Contracts/IRawDataServiceRestClientBase.cs
+++ b/src/Api.Rest/Contracts/IRawDataServiceRestClientBase.cs
@@ -17,7 +17,6 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 	using System.Threading;
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
-	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;
 	using Zeiss.PiWeb.Api.Rest.Dtos.RawData;
 

--- a/src/Api.Rest/Contracts/IRawDataServiceRestClientBase.cs
+++ b/src/Api.Rest/Contracts/IRawDataServiceRestClientBase.cs
@@ -17,6 +17,7 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 	using System.Threading;
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
+	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;
 	using Zeiss.PiWeb.Api.Rest.Dtos.RawData;
 
@@ -24,6 +25,15 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 
 	public interface IRawDataServiceRestClientBase<T> where T : RawDataServiceFeatureMatrix
 	{
+		#region properties
+
+		/// <summary>
+		/// A custom rest client that can be used to execute rest request created by a rest request builder.
+		/// </summary>
+		public ICustomRestClient CustomRestClient { get; }
+
+		#endregion
+
 		#region methods
 
 		/// <summary>
@@ -40,11 +50,21 @@ namespace Zeiss.PiWeb.Api.Rest.Contracts
 		Task<InterfaceVersionRange> GetInterfaceInformation( CancellationToken cancellationToken = default );
 
 		/// <summary>
-		/// Method for fetching the <see cref="RawDataServiceFeatureMatrix"/>
+		/// Returns a <see cref="RawDataServiceFeatureMatrix"/> that describes features and abilities of the server for the
+		/// raw data service endpoint.
 		/// </summary>
 		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-		/// <returns></returns>
 		Task<T> GetFeatureMatrix( CancellationToken cancellationToken = default );
+
+		/// <summary>
+		/// Returns a <see cref="RawDataServiceFeatureMatrix"/> that describes features and abilities of the server for the
+		/// raw data service endpoint.
+		/// </summary>
+		/// <param name="refreshPolicy">
+		/// Specifies if a previous result can be returned or if the server should be queried again requiring at least one rest request.
+		/// </param>
+		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+		Task<RawDataServiceFeatureMatrix> GetFeatureMatrix( RefreshPolicy refreshPolicy, CancellationToken cancellationToken = default );
 
 		/// <summary>
 		/// Fetches a list of raw data information for the <paramref name="entity"/> identified by <paramref name="uuids"/> and filtered by <paramref name="filter"/>.

--- a/src/Api.Rest/Contracts/RefreshPolicy.cs
+++ b/src/Api.Rest/Contracts/RefreshPolicy.cs
@@ -3,7 +3,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Carl Zeiss Industrielle Messtechnik GmbH        */
 /* Softwaresystem PiWeb                            */
-/* (c) Carl Zeiss 2016                             */
+/* (c) Carl Zeiss 2024                             */
 /* * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #endregion

--- a/src/Api.Rest/Contracts/RefreshPolicy.cs
+++ b/src/Api.Rest/Contracts/RefreshPolicy.cs
@@ -1,0 +1,28 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2016                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Contracts;
+
+/// <summary>
+/// Represents the different result refresh policies available for some rest client requests.
+/// </summary>
+public enum RefreshPolicy
+{
+	/// <summary>
+	/// If a previous result exists, it will be returned again avoiding any rest communication. Otherwise, a new result will be fetched
+	/// requiring at least one rest request.
+	/// </summary>
+	UseLatestResult,
+
+	/// <summary>
+	/// A new result will be fetched even when a previous result already exists.
+	/// </summary>
+	RefreshAlways
+}

--- a/src/Api.Rest/HttpClient/Builder/IRestClientBuilder.cs
+++ b/src/Api.Rest/HttpClient/Builder/IRestClientBuilder.cs
@@ -1,0 +1,39 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
+
+using Zeiss.PiWeb.Api.Rest.HttpClient.Data;
+using Zeiss.PiWeb.Api.Rest.HttpClient.OAuth;
+using Zeiss.PiWeb.Api.Rest.HttpClient.RawData;
+
+/// <summary>
+/// Responsible for building PiWeb API rest clients.
+/// </summary>
+public interface IRestClientBuilder
+{
+	/// <summary>
+	/// Creates a data service rest client using the current setup.
+	/// </summary>
+	/// <returns>The created data service rest client.</returns>
+	public DataServiceRestClient CreateDataServiceRestClient();
+
+	/// <summary>
+	/// Creates a raw data service rest client using the current setup.
+	/// </summary>
+	/// <returns>The created raw data service rest client.</returns>
+	public RawDataServiceRestClient CreateRawDataServiceRestClient();
+
+	/// <summary>
+	/// Creates an oauth data service rest client using the current setup.
+	/// </summary>
+	/// <returns>The created raw data service rest client.</returns>
+	public OAuthServiceRestClient CreateOAuthServiceRestClient();
+}

--- a/src/Api.Rest/HttpClient/Builder/IRestClientBuilder.cs
+++ b/src/Api.Rest/HttpClient/Builder/IRestClientBuilder.cs
@@ -34,6 +34,6 @@ public interface IRestClientBuilder
 	/// <summary>
 	/// Creates an oauth data service rest client using the current setup.
 	/// </summary>
-	/// <returns>The created raw data service rest client.</returns>
+	/// <returns>The created oauth service rest client.</returns>
 	public OAuthServiceRestClient CreateOAuthServiceRestClient();
 }

--- a/src/Api.Rest/HttpClient/Builder/RestClientBuilder.cs
+++ b/src/Api.Rest/HttpClient/Builder/RestClientBuilder.cs
@@ -10,6 +10,8 @@
 
 namespace Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
 
+#region usings
+
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -23,6 +25,8 @@ using Zeiss.PiWeb.Api.Rest.HttpClient.Data;
 using Zeiss.PiWeb.Api.Rest.HttpClient.OAuth;
 using Zeiss.PiWeb.Api.Rest.HttpClient.RawData;
 
+#endregion
+
 /// <summary>
 /// <inheritdoc cref="Zeiss.PiWeb.Api.Rest.HttpClient.Builder.IRestClientBuilder" />
 /// Using this builder should be preferred over directly instantiating a rest client.
@@ -32,15 +36,17 @@ using Zeiss.PiWeb.Api.Rest.HttpClient.RawData;
 /// </summary>
 public class RestClientBuilder : IRestClientBuilder, IDisposable
 {
+	#region members
+
 	// The internal cache store used when http caching is enabled and no external cache store is set.
 	private readonly Lazy<ICacheStore> _InternalSharedCacheStore = new(
 		() => new InMemoryCacheStore(),
-		LazyThreadSafetyMode.ExecutionAndPublication );
+		LazyThreadSafetyMode.ExecutionAndPublication);
 
 	// The internal vary header store used when http caching is enabled and no external vary header store is set.
 	private readonly Lazy<IVaryHeaderStore> _InternalSharedVaryHeaderStore = new(
 		() => new InMemoryVaryHeaderStore(),
-		LazyThreadSafetyMode.ExecutionAndPublication );
+		LazyThreadSafetyMode.ExecutionAndPublication);
 
 	// Factories used for creating a delegating handler chains
 	[NotNull] private readonly List<Func<DelegatingHandler>> _DelegatingHandlerFactories = new List<Func<DelegatingHandler>>();
@@ -104,6 +110,10 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// </summary>
 	[CanBeNull] private IAuthenticationHandler _AuthenticationHandler;
 
+	#endregion
+
+	#region constructors
+
 	/// <summary>
 	/// Initializes a new instance of the <see cref="RestClientBuilder"/> class.
 	/// </summary>
@@ -116,6 +126,10 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 
 		_ServerUri = serverUri;
 	}
+
+	#endregion
+
+	#region methods
 
 	/// <summary>
 	/// Creates an instance of <see cref="RestClientSettings"/> representing the current configuration of this builder.
@@ -144,7 +158,7 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// Sets the timespan to wait before rest requests time out. Default value is 5 minutes.
 	/// </summary>
 	/// <param name="timeout">The timespan to wait.</param>
-	public virtual RestClientBuilder SetTimeout(TimeSpan timeout)
+	public virtual RestClientBuilder SetTimeout( TimeSpan timeout )
 	{
 		_Timeout = timeout;
 		return this;
@@ -154,7 +168,7 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// Sets the timespan to wait before rest requests time out to a predefined value. Default timeout is 5 minutes.
 	/// </summary>
 	/// <param name="timeoutType">The standard timeout to set.</param>
-	public virtual RestClientBuilder SetStandardTimeout(StandardTimeoutType timeoutType)
+	public virtual RestClientBuilder SetStandardTimeout( StandardTimeoutType timeoutType )
 	{
 		_Timeout = timeoutType switch
 		{
@@ -171,7 +185,7 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// Sets the maximum length of URIs generated for rest requests. Default value is 8192.
 	/// </summary>
 	/// <param name="maxUriLength">The maximum length.</param>
-	public virtual RestClientBuilder SetMaxUriLength(int maxUriLength)
+	public virtual RestClientBuilder SetMaxUriLength( int maxUriLength )
 	{
 		_MaxUriLength = maxUriLength;
 		return this;
@@ -182,7 +196,7 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// Default value is 8.
 	/// </summary>
 	/// <param name="maxRequests">The maximum number of requests that may occur in parallel.</param>
-	public virtual RestClientBuilder SetMaxRequestsInParallel(int maxRequests)
+	public virtual RestClientBuilder SetMaxRequestsInParallel( int maxRequests )
 	{
 		_MaxRequestsInParallel = maxRequests;
 		return this;
@@ -192,7 +206,7 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// Specifies whether chunked transfer encoding should be used. Default value is <c>true</c>.
 	/// </summary>
 	/// <param name="allowed"><c>True</c> if chunked transfer encoding should be used; otherwise, <c>false</c>.</param>
-	public virtual RestClientBuilder SetAllowChunkedTransferEncoding(bool allowed)
+	public virtual RestClientBuilder SetAllowChunkedTransferEncoding( bool allowed )
 	{
 		_AllowChunkedDataTransfer = allowed;
 		return this;
@@ -203,7 +217,7 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// <see cref="ObjectSerializer.SystemTextJsonSerializer"/>.
 	/// </summary>
 	/// <param name="serializer">The custom serializer implementation.</param>
-	public virtual RestClientBuilder SetCustomSerializer( [NotNull] IObjectSerializer serializer)
+	public virtual RestClientBuilder SetCustomSerializer( [NotNull] IObjectSerializer serializer )
 	{
 		_Serializer = serializer ?? throw new ArgumentNullException( nameof( serializer ) );
 		return this;
@@ -232,7 +246,7 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// </summary>
 	public virtual RestClientBuilder EnableExternalHttpCaching(
 		[NotNull] ICacheStore cacheStore,
-		[NotNull] IVaryHeaderStore varyHeaderStore)
+		[NotNull] IVaryHeaderStore varyHeaderStore )
 	{
 		_HttpCachingEnabled = true;
 		_CacheStore = cacheStore ?? throw new ArgumentNullException( nameof( cacheStore ) );
@@ -303,6 +317,36 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 		return this;
 	}
 
+	/// <summary>
+	/// Performs cleanup.
+	/// </summary>
+	/// <param name="disposing">
+	/// Indicates whether the method call comes from a Dispose method (<c>true</c>) or from a finalizer (<c>false</c>).
+	/// </param>
+	protected virtual void Dispose( bool disposing )
+	{
+		if( _InternalSharedCacheStore.IsValueCreated )
+			_InternalSharedCacheStore.Value.Dispose();
+
+		if( _InternalSharedVaryHeaderStore.IsValueCreated )
+			_InternalSharedVaryHeaderStore.Value.Dispose();
+	}
+
+	#endregion
+
+	#region interface IDisposable
+
+	/// <inheritdoc />
+	public void Dispose()
+	{
+		Dispose( true );
+		GC.SuppressFinalize( this );
+	}
+
+	#endregion
+
+	#region interface IRestClientBuilder
+
 	/// <inheritdoc />
 	public DataServiceRestClient CreateDataServiceRestClient()
 	{
@@ -322,25 +366,5 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 		return new OAuthServiceRestClient( GetSettings() );
 	}
 
-	/// <summary>
-	/// Performs cleanup.
-	/// </summary>
-	/// <param name="disposing">
-	/// Indicates whether the method call comes from a Dispose method (<c>true</c>) or from a finalizer (<c>false</c>).
-	/// </param>
-	protected virtual void Dispose( bool disposing )
-	{
-		if( _InternalSharedCacheStore.IsValueCreated )
-			_InternalSharedCacheStore.Value.Dispose();
-
-		if( _InternalSharedVaryHeaderStore.IsValueCreated )
-			_InternalSharedVaryHeaderStore.Value.Dispose();
-	}
-
-	/// <inheritdoc />
-	public void Dispose()
-	{
-		Dispose( true );
-		GC.SuppressFinalize( this );
-	}
+	#endregion
 }

--- a/src/Api.Rest/HttpClient/Builder/RestClientBuilder.cs
+++ b/src/Api.Rest/HttpClient/Builder/RestClientBuilder.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using CacheCow.Client;
 using CacheCow.Common;
 using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Authentication;
 using Zeiss.PiWeb.Api.Rest.Common.Client;
 using Zeiss.PiWeb.Api.Rest.HttpClient.Data;
 using Zeiss.PiWeb.Api.Rest.HttpClient.OAuth;
@@ -97,6 +98,11 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// Specifies whether a system-wide http proxy setting will be respected.
 	/// </summary>
 	private bool _UseSystemProxy = true;
+
+	/// <summary>
+	/// The authentication handler or <c>null</c> when no handler is set.
+	/// </summary>
+	[CanBeNull] private IAuthenticationHandler _AuthenticationHandler;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="RestClientBuilder"/> class.
@@ -282,6 +288,15 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	public virtual RestClientBuilder ClearDelegatingHandlerFactories()
 	{
 		_DelegatingHandlerFactories.Clear();
+		return this;
+	}
+
+	/// <summary>
+	/// Sets a handler used to define the authentication behavior of all rest clients.
+	/// </summary>
+	public virtual RestClientBuilder SetAuthenticationHandler( [CanBeNull] IAuthenticationHandler authenticationHandler )
+	{
+		_AuthenticationHandler = authenticationHandler;
 		return this;
 	}
 

--- a/src/Api.Rest/HttpClient/Builder/RestClientBuilder.cs
+++ b/src/Api.Rest/HttpClient/Builder/RestClientBuilder.cs
@@ -1,0 +1,327 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using CacheCow.Client;
+using CacheCow.Common;
+using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Client;
+using Zeiss.PiWeb.Api.Rest.HttpClient.Data;
+using Zeiss.PiWeb.Api.Rest.HttpClient.OAuth;
+using Zeiss.PiWeb.Api.Rest.HttpClient.RawData;
+
+/// <summary>
+/// <inheritdoc cref="Zeiss.PiWeb.Api.Rest.HttpClient.Builder.IRestClientBuilder" />
+/// Using this builder should be preferred over directly instantiating a rest client.
+/// In its default setup this builder uses an internal http cache for any rest client build. This cache is disposed when this builder is
+/// disposed. This means the builder needs to life longer then any rest client it builds. It is possible to use an external cache instead
+/// by calling <see cref="EnableExternalHttpCaching"/>.
+/// </summary>
+public class RestClientBuilder : IRestClientBuilder, IDisposable
+{
+	// The internal cache store used when http caching is enabled and no external cache store is set.
+	private readonly Lazy<ICacheStore> _InternalSharedCacheStore = new(
+		() => new InMemoryCacheStore(),
+		LazyThreadSafetyMode.ExecutionAndPublication );
+
+	// The internal vary header store used when http caching is enabled and no external vary header store is set.
+	private readonly Lazy<IVaryHeaderStore> _InternalSharedVaryHeaderStore = new(
+		() => new InMemoryVaryHeaderStore(),
+		LazyThreadSafetyMode.ExecutionAndPublication );
+
+	// Factories used for creating a delegating handler chains
+	[NotNull] private readonly List<Func<DelegatingHandler>> _DelegatingHandlerFactories = new List<Func<DelegatingHandler>>();
+
+	/// <summary>
+	/// The uri of the PiWeb Server to connect to. This uri must include a port and also an instance id if required.
+	/// </summary>
+	[NotNull] private readonly Uri _ServerUri;
+
+	/// <summary>
+	/// The timespan to wait before rest requests time out. Default value is 5 minutes.
+	/// </summary>
+	private TimeSpan _Timeout = RestClientBase.DefaultTimeout;
+
+	/// <summary>
+	/// The maximum length of URIs generated for rest requests. Default value is 8192.
+	/// </summary>
+	private int _MaxUriLength = RestClientBase.DefaultMaxUriLength;
+
+	/// <summary>
+	/// The maximum number of parallel requests that may occur when splitting requests because of the maximum uri length.
+	/// Default value is 8.
+	/// </summary>
+	private int _MaxRequestsInParallel = 8;
+
+	/// <summary>
+	/// Indicates whether chunked transfer encoding should be used. Default value is <c>true</c>.
+	/// </summary>
+	private bool _AllowChunkedDataTransfer = true;
+
+	/// <summary>
+	/// The serializer to use for serializing and deserializing of data transfer objects. Default value is
+	/// <see cref="ObjectSerializer.Default"/>.
+	/// </summary>
+	[NotNull] private IObjectSerializer _Serializer = ObjectSerializer.Default;
+
+	/// <summary>
+	/// Indicates whether http caching is enabled. Default value is <c>null</c>.
+	/// </summary>
+	private bool _HttpCachingEnabled = true;
+
+	/// <summary>
+	/// The external cache store to use for http caching or <c>null</c> if an internal cache store should be used.
+	/// Default value is <c>null</c>.
+	/// </summary>
+	[CanBeNull] private ICacheStore _CacheStore;
+
+	/// <summary>
+	/// The external vary header store to use for http caching or <c>null</c> if an internal vary header store should be used.
+	/// Default value is <c>null</c>.
+	/// </summary>
+	[CanBeNull] private IVaryHeaderStore _VaryHeaderStore;
+
+	/// <summary>
+	/// Specifies whether a system-wide http proxy setting will be respected.
+	/// </summary>
+	private bool _UseSystemProxy = true;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="RestClientBuilder"/> class.
+	/// </summary>
+	/// <param name="serverUri">The uri of the rest services.</param>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="serverUri"/> is <c>null</c>.</exception>
+	public RestClientBuilder( [NotNull] Uri serverUri )
+	{
+		if( serverUri == null )
+			throw new ArgumentNullException( nameof( serverUri ) );
+
+		_ServerUri = serverUri;
+	}
+
+	/// <summary>
+	/// Creates an instance of <see cref="RestClientSettings"/> representing the current configuration of this builder.
+	/// </summary>
+	public RestClientSettings GetSettings()
+	{
+		return new RestClientSettings()
+		{
+			ServerUri = _ServerUri,
+			Timeout = _Timeout,
+			MaxUriLength = _MaxUriLength,
+			MaxRequestsInParallel = _MaxRequestsInParallel,
+			AllowChunkedDataTransfer = _AllowChunkedDataTransfer,
+			Serializer = _Serializer,
+			CacheStore = _CacheStore ?? ( _HttpCachingEnabled ? _InternalSharedCacheStore.Value : null ),
+			VaryHeaderStore = _VaryHeaderStore ?? ( _HttpCachingEnabled ? _InternalSharedVaryHeaderStore.Value : null ),
+			UseSystemProxy = _UseSystemProxy,
+			DelegatingHandlerFactories = new List<Func<DelegatingHandler>>( _DelegatingHandlerFactories )
+		};
+	}
+
+	/// <summary>
+	/// Sets the timespan to wait before rest requests time out. Default value is 5 minutes.
+	/// </summary>
+	/// <param name="timeout">The timespan to wait.</param>
+	public virtual RestClientBuilder SetTimeout(TimeSpan timeout)
+	{
+		_Timeout = timeout;
+		return this;
+	}
+
+	/// <summary>
+	/// Sets the timespan to wait before rest requests time out to a predefined value. Default timeout is 5 minutes.
+	/// </summary>
+	/// <param name="timeoutType">The standard timeout to set.</param>
+	public virtual RestClientBuilder SetStandardTimeout(StandardTimeoutType timeoutType)
+	{
+		_Timeout = timeoutType switch
+		{
+			StandardTimeoutType.Default         => RestClientBase.DefaultTimeout,
+			StandardTimeoutType.ConnectionCheck => RestClientBase.DefaultTestTimeout,
+			StandardTimeoutType.ShortOperation  => RestClientBase.DefaultShortTimeout,
+			StandardTimeoutType.Infinite        => Timeout.InfiniteTimeSpan,
+			_                                   => throw new ArgumentOutOfRangeException( nameof( timeoutType ), timeoutType, null )
+		};
+		return this;
+	}
+
+	/// <summary>
+	/// Sets the maximum length of URIs generated for rest requests. Default value is 8192.
+	/// </summary>
+	/// <param name="maxUriLength">The maximum length.</param>
+	public virtual RestClientBuilder SetMaxUriLength(int maxUriLength)
+	{
+		_MaxUriLength = maxUriLength;
+		return this;
+	}
+
+	/// <summary>
+	/// Sets the maximum number of parallel requests that may occur when splitting requests because of the maximum uri length.
+	/// Default value is 8.
+	/// </summary>
+	/// <param name="maxRequests">The maximum number of requests that may occur in parallel.</param>
+	public virtual RestClientBuilder SetMaxRequestsInParallel(int maxRequests)
+	{
+		_MaxRequestsInParallel = maxRequests;
+		return this;
+	}
+
+	/// <summary>
+	/// Specifies whether chunked transfer encoding should be used. Default value is <c>true</c>.
+	/// </summary>
+	/// <param name="allowed"><c>True</c> if chunked transfer encoding should be used; otherwise, <c>false</c>.</param>
+	public virtual RestClientBuilder SetAllowChunkedTransferEncoding(bool allowed)
+	{
+		_AllowChunkedDataTransfer = allowed;
+		return this;
+	}
+
+	/// <summary>
+	/// Sets a custom serializer implementation to use for serializing and deserializing of data transfer objects. Default value is
+	/// <see cref="ObjectSerializer.SystemTextJsonSerializer"/>.
+	/// </summary>
+	/// <param name="serializer">The custom serializer implementation.</param>
+	public virtual RestClientBuilder SetCustomSerializer( [NotNull] IObjectSerializer serializer)
+	{
+		_Serializer = serializer ?? throw new ArgumentNullException( nameof( serializer ) );
+		return this;
+	}
+
+	/// <summary>
+	/// Enables http caching using internal cache implementations shared for all rest clients created with this builder.
+	/// This corresponds to the default state.
+	/// </summary>
+	/// <remarks>
+	/// The shared internal cache is disposed when this builder is disposed. You need to make sure this builder lives longer than any
+	/// rest client created by this builder. Use <see cref="EnableExternalHttpCaching"/> instead to have explicit control over the lifetime
+	/// of the cache.
+	/// </remarks>
+	public virtual RestClientBuilder EnableStandardHttpCaching()
+	{
+		_HttpCachingEnabled = true;
+		_CacheStore = null; // forces use of the internal cache store
+		_VaryHeaderStore = null; // forces use of the internal vary header store
+
+		return this;
+	}
+
+	/// <summary>
+	/// Sets an externally provided cache store and very header store to be used as http cache.
+	/// </summary>
+	public virtual RestClientBuilder EnableExternalHttpCaching(
+		[NotNull] ICacheStore cacheStore,
+		[NotNull] IVaryHeaderStore varyHeaderStore)
+	{
+		_HttpCachingEnabled = true;
+		_CacheStore = cacheStore ?? throw new ArgumentNullException( nameof( cacheStore ) );
+		_VaryHeaderStore = varyHeaderStore ?? throw new ArgumentNullException( nameof( varyHeaderStore ) );
+
+		return this;
+	}
+
+	/// <summary>
+	/// Disables http caching entirely.
+	/// </summary>
+	public virtual RestClientBuilder DisableHttpCaching()
+	{
+		_HttpCachingEnabled = false;
+		_CacheStore = null;
+		_VaryHeaderStore = null;
+
+		return this;
+	}
+
+	/// <summary>
+	/// Specifies if a system wide http proxy should be used if such a proxy is set up for the system. The default value is <c>true</c>.
+	/// </summary>
+	public virtual RestClientBuilder SetUseSystemHttpProxy( bool useSystemProxy )
+	{
+		_UseSystemProxy = useSystemProxy;
+		return this;
+	}
+
+	/// <summary>
+	/// Adds a factory for delegating handlers. By adding factories, custom delegating handlers implementing additional functionality can
+	/// be added to rest clients. When a new rest client is build by this builder, the given factories are used to create a chain
+	/// of <see cref="DelegatingHandler"/>s to be used by the inner <see cref="HttpClient"/> instance on top of the internal http message
+	/// handler.
+	/// Any instance of a <see cref="DelegatingHandler"/> can only be part of a single chain. Avoid reusing any
+	/// <see cref="DelegatingHandler"/> instances in your factories once they are part of a chain as this may result in exceptions or
+	/// unpredictable behavior on other rest clients.
+	/// </summary>
+	/// <param name="factory">The delegating handler factory to add.</param>
+	/// <exception cref="ArgumentNullException">Thrown when factory is <c>null</c>.</exception>
+	public virtual RestClientBuilder AddDelegatingHandlerFactory( [NotNull] Func<DelegatingHandler> factory )
+	{
+		// Normally I would like to add the delegating handlers instances directly without any factory methods (similar to what
+		// IHttpClientFactory does). However, currently we do not share a common HttpClient instance between different rest clients and
+		// even create new HttpClient instances within a rest client on certain occasions. Using factories here allows us to build a new
+		// chain per HttpClient instance.
+
+		_DelegatingHandlerFactories.Add( factory ?? throw new ArgumentNullException( nameof( factory ) ) );
+		return this;
+	}
+
+	/// <summary>
+	/// Clears all delegating handler factories added previously. No additional delegating handlers are added to the chain.
+	/// This is the default setup.
+	/// </summary>
+	public virtual RestClientBuilder ClearDelegatingHandlerFactories()
+	{
+		_DelegatingHandlerFactories.Clear();
+		return this;
+	}
+
+	/// <inheritdoc />
+	public DataServiceRestClient CreateDataServiceRestClient()
+	{
+		return new DataServiceRestClient( GetSettings() );
+	}
+
+	/// <inheritdoc />
+	public RawDataServiceRestClient CreateRawDataServiceRestClient()
+	{
+		return new RawDataServiceRestClient( GetSettings() );
+	}
+
+	/// <inheritdoc />
+	public OAuthServiceRestClient CreateOAuthServiceRestClient()
+	{
+		return new OAuthServiceRestClient( GetSettings() );
+	}
+
+	/// <summary>
+	/// Performs cleanup.
+	/// </summary>
+	/// <param name="disposing">
+	/// Indicates whether the method call comes from a Dispose method (<c>true</c>) or from a finalizer (<c>false</c>).
+	/// </param>
+	protected virtual void Dispose( bool disposing )
+	{
+		if( _InternalSharedCacheStore.IsValueCreated )
+			_InternalSharedCacheStore.Value.Dispose();
+
+		if( _InternalSharedVaryHeaderStore.IsValueCreated )
+			_InternalSharedVaryHeaderStore.Value.Dispose();
+	}
+
+	/// <inheritdoc />
+	public void Dispose()
+	{
+		Dispose( true );
+		GC.SuppressFinalize( this );
+	}
+}

--- a/src/Api.Rest/HttpClient/Builder/RestClientBuilder.cs
+++ b/src/Api.Rest/HttpClient/Builder/RestClientBuilder.cs
@@ -122,7 +122,7 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// </summary>
 	public RestClientSettings GetSettings()
 	{
-		return new RestClientSettings()
+		var settings = new RestClientSettings()
 		{
 			ServerUri = _ServerUri,
 			Timeout = _Timeout,
@@ -133,8 +133,11 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 			CacheStore = _CacheStore ?? ( _HttpCachingEnabled ? _InternalSharedCacheStore.Value : null ),
 			VaryHeaderStore = _VaryHeaderStore ?? ( _HttpCachingEnabled ? _InternalSharedVaryHeaderStore.Value : null ),
 			UseSystemProxy = _UseSystemProxy,
-			DelegatingHandlerFactories = new List<Func<DelegatingHandler>>( _DelegatingHandlerFactories )
+			DelegatingHandlerFactories = new List<Func<DelegatingHandler>>( _DelegatingHandlerFactories ),
+			AuthenticationHandler = _AuthenticationHandler
 		};
+
+		return settings;
 	}
 
 	/// <summary>
@@ -303,7 +306,8 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// <inheritdoc />
 	public DataServiceRestClient CreateDataServiceRestClient()
 	{
-		return new DataServiceRestClient( GetSettings() );
+		var settings = GetSettings();
+		return new DataServiceRestClient( settings );
 	}
 
 	/// <inheritdoc />

--- a/src/Api.Rest/HttpClient/Builder/RestClientSettings.cs
+++ b/src/Api.Rest/HttpClient/Builder/RestClientSettings.cs
@@ -1,0 +1,87 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
+
+#region usings
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using CacheCow.Client;
+using CacheCow.Common;
+using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Client;
+
+#endregion
+
+/// <summary>
+/// Represents settings for a PiWeb rest client.
+/// </summary>
+public record RestClientSettings
+{
+	#region properties
+
+	/// <summary>
+	/// The uri of the PiWeb Server to connect to. This uri must include a port and also an instance id if required.
+	/// </summary>
+	[NotNull]
+	public Uri ServerUri { get; set; } = new Uri( "http://localhost/" );
+
+	/// <summary>
+	/// The timespan to wait before rest requests time out.
+	/// </summary>
+	public TimeSpan Timeout { get; set; } = RestClientBase.DefaultTimeout;
+
+	/// <summary>
+	/// The maximum length of URIs generated for rest requests.
+	/// </summary>
+	public int MaxUriLength { get; set; } = RestClientBase.DefaultMaxUriLength;
+
+	/// <summary>
+	/// The maximum number of parallel requests that may occur when splitting requests because of the maximum uri length.
+	/// </summary>
+	public int MaxRequestsInParallel { get; set; } = 8;
+
+	/// <summary>
+	/// Indicates whether chunked transfer encoding should be used.
+	/// </summary>
+	public bool AllowChunkedDataTransfer { get; set; } = true;
+
+	/// <summary>
+	/// The serializer to use for serializing and deserializing of data transfer objects.
+	/// </summary>
+	[NotNull]
+	public IObjectSerializer Serializer { get; set; } = ObjectSerializer.Default;
+
+	/// <summary>
+	/// The external cache store to use for http caching or <c>null</c> if an internal cache store should be used.
+	/// </summary>
+	[CanBeNull]
+	public ICacheStore CacheStore { get; set; }
+
+	/// <summary>
+	/// The external vary header store to use for http caching or <c>null</c> if an internal vary header store should be used.
+	/// </summary>
+	[CanBeNull]
+	public IVaryHeaderStore VaryHeaderStore { get; set; }
+
+	/// <summary>
+	/// Specifies whether a system-wide http proxy setting will be respected.
+	/// </summary>
+	public bool UseSystemProxy { get; set; } = true;
+
+	/// <summary>
+	/// The delegating handler factories to use for creating delegating handler chains.
+	/// </summary>
+	public IReadOnlyCollection<Func<DelegatingHandler>> DelegatingHandlerFactories { get; set; }
+
+	#endregion
+}

--- a/src/Api.Rest/HttpClient/Builder/RestClientSettings.cs
+++ b/src/Api.Rest/HttpClient/Builder/RestClientSettings.cs
@@ -18,6 +18,7 @@ using System.Net.Http;
 using CacheCow.Client;
 using CacheCow.Common;
 using JetBrains.Annotations;
+using Zeiss.PiWeb.Api.Rest.Common.Authentication;
 using Zeiss.PiWeb.Api.Rest.Common.Client;
 
 #endregion
@@ -82,6 +83,12 @@ public record RestClientSettings
 	/// The delegating handler factories to use for creating delegating handler chains.
 	/// </summary>
 	public IReadOnlyCollection<Func<DelegatingHandler>> DelegatingHandlerFactories { get; set; }
+
+	/// <summary>
+	/// The authentication handler or <c>null</c> when no handler is set.
+	/// </summary>
+	[CanBeNull]
+	public IAuthenticationHandler AuthenticationHandler { get; set; }
 
 	#endregion
 }

--- a/src/Api.Rest/HttpClient/Builder/StandardTimeoutType.cs
+++ b/src/Api.Rest/HttpClient/Builder/StandardTimeoutType.cs
@@ -1,0 +1,37 @@
+#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
+
+/// <summary>
+/// Enumerates standard timeout values uses for rest requests.
+/// </summary>
+public enum StandardTimeoutType
+{
+	/// <summary>
+	/// Timeout for standard operations: 5 minutes.
+	/// </summary>
+	Default,
+
+	/// <summary>
+	/// Timeout for connection checks: 5 seconds.
+	/// </summary>
+	ConnectionCheck,
+
+	/// <summary>
+	/// Timeout for short operations: 15 seconds.
+	/// </summary>
+	ShortOperation,
+
+	/// <summary>
+	/// Infinite timeout.
+	/// </summary>
+	Infinite
+}

--- a/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
@@ -22,6 +22,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 	using Zeiss.PiWeb.Api.Core;
 	using Zeiss.PiWeb.Api.Definitions;
 	using Zeiss.PiWeb.Api.Rest.Common.Client;
+	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Common.Data;
 	using Zeiss.PiWeb.Api.Rest.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;
@@ -456,6 +457,9 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 		#region interface IDataServiceRestClient
 
 		/// <inheritdoc />
+		public ICustomRestClient CustomRestClient => _RestClient;
+
+		/// <inheritdoc />
 		public async Task<ServiceInformationDto> GetServiceInformation( CancellationToken cancellationToken = default )
 		{
 			var serviceInformation = await GetServiceInformationInternal( FetchBehavior.FetchAlways, cancellationToken ).ConfigureAwait( false );
@@ -475,7 +479,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 			{
 				if( ex.StatusCode != HttpStatusCode.NotFound ) throw;
 
-				// this call didn't exist in Version 1.0.0. We interprete the missing endpoint as Version 1.0.0
+				// this call didn't exist in Version 1.0.0. We interpret the missing endpoint as Version 1.0.0
 				return new InterfaceVersionRange { SupportedVersions = new[] { new Version( 1, 0, 0 ) } };
 			}
 		}
@@ -483,7 +487,19 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 		/// <inheritdoc />
 		public Task<DataServiceFeatureMatrix> GetFeatureMatrix( CancellationToken cancellationToken = default )
 		{
-			return GetFeatureMatrixInternal( FetchBehavior.FetchAlways, cancellationToken );
+			return GetFeatureMatrix( RefreshPolicy.RefreshAlways, cancellationToken );
+		}
+
+		/// <inheritdoc />
+		public Task<DataServiceFeatureMatrix> GetFeatureMatrix(
+			RefreshPolicy refreshPolicy,
+			CancellationToken cancellationToken = default )
+		{
+			var fetchBehavior = refreshPolicy == RefreshPolicy.UseLatestResult
+				? FetchBehavior.FetchIfNotCached
+				: FetchBehavior.FetchAlways;
+
+			return GetFeatureMatrixInternal( fetchBehavior, cancellationToken );
 		}
 
 		/// <inheritdoc />

--- a/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
@@ -22,7 +22,6 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 	using Zeiss.PiWeb.Api.Core;
 	using Zeiss.PiWeb.Api.Definitions;
 	using Zeiss.PiWeb.Api.Rest.Common.Client;
-	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Common.Data;
 	using Zeiss.PiWeb.Api.Rest.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;

--- a/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/Data/DataServiceRestClient.cs
@@ -26,6 +26,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 	using Zeiss.PiWeb.Api.Rest.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;
 	using Zeiss.PiWeb.Api.Rest.Dtos.Data;
+	using Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
 
 	#endregion
 
@@ -36,7 +37,10 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 	{
 		#region constants
 
-		private const string EndpointName = "DataServiceRest/";
+		/// <summary>
+		/// The name of the endpoint of this service.
+		/// </summary>
+		public const string EndpointName = "DataServiceRest/";
 
 		#endregion
 
@@ -61,6 +65,16 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.Data
 			: base( restClient ?? new RestClient( serverUri, EndpointName, maxUriLength: maxUriLength, serializer: ObjectSerializer.SystemTextJson ) )
 		{
 			_MaxRequestsInParallel = maxRequestsInParallel;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="DataServiceRestClient"/> class.
+		/// </summary>
+		/// <param name="settings">The settings of the rest service.</param>
+		internal DataServiceRestClient( RestClientSettings settings )
+			: base( new RestClient( EndpointName, settings ) )
+		{
+			_MaxRequestsInParallel = settings.MaxRequestsInParallel;
 		}
 
 		#endregion

--- a/src/Api.Rest/HttpClient/OAuth/IOAuthServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/OAuth/IOAuthServiceRestClient.cs
@@ -15,6 +15,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Zeiss.PiWeb.Api.Rest.Common.Client;
+	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 
 	#endregion
 
@@ -23,6 +24,15 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth
 	/// </summary>
 	public interface IOAuthServiceRestClient : IRestClient
 	{
+		#region properties
+
+		/// <summary>
+		/// A custom rest client that can be used to execute rest request created by a rest request builder.
+		/// </summary>
+		public ICustomRestClient CustomRestClient { get; }
+
+		#endregion
+
 		#region methods
 
 		/// <summary>

--- a/src/Api.Rest/HttpClient/OAuth/IOAuthServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/OAuth/IOAuthServiceRestClient.cs
@@ -15,7 +15,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth
 	using System.Threading;
 	using System.Threading.Tasks;
 	using Zeiss.PiWeb.Api.Rest.Common.Client;
-	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
+	using Zeiss.PiWeb.Api.Rest.Contracts;
 
 	#endregion
 

--- a/src/Api.Rest/HttpClient/OAuth/OAuthServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/OAuth/OAuthServiceRestClient.cs
@@ -17,6 +17,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
 	using Zeiss.PiWeb.Api.Rest.Common.Client;
+	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 	using Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
 
 	#endregion
@@ -59,6 +60,9 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth
 		#endregion
 
 		#region interface IOAuthServiceRestClient
+
+		/// <inheritdoc />
+		public ICustomRestClient CustomRestClient => _RestClient;
 
 		/// <summary>
 		/// Get information about valid OAuth issues authorities and resource ids.

--- a/src/Api.Rest/HttpClient/OAuth/OAuthServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/OAuth/OAuthServiceRestClient.cs
@@ -17,7 +17,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
 	using Zeiss.PiWeb.Api.Rest.Common.Client;
-	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
+	using Zeiss.PiWeb.Api.Rest.Contracts;
 	using Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
 
 	#endregion

--- a/src/Api.Rest/HttpClient/OAuth/OAuthServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/OAuth/OAuthServiceRestClient.cs
@@ -17,6 +17,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
 	using Zeiss.PiWeb.Api.Rest.Common.Client;
+	using Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
 
 	#endregion
 
@@ -25,6 +26,15 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth
 	/// </summary>
 	public class OAuthServiceRestClient : CommonRestClientBase, IOAuthServiceRestClient
 	{
+		#region constants
+
+		/// <summary>
+		/// The name of the endpoint of this service.
+		/// </summary>
+		public const string EndpointName = "OAuthServiceRest/";
+
+		#endregion
+
 		#region constructors
 
 		/// <summary>
@@ -35,7 +45,15 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth
 		/// </param>
 		/// <exception cref="ArgumentNullException"><paramref name="serverUri"/> is <see langword="null" />.</exception>
 		public OAuthServiceRestClient( [NotNull] Uri serverUri )
-			: base( new RestClient( serverUri, "OAuthServiceRest/", serializer: ObjectSerializer.SystemTextJson ) )
+			: base( new RestClient( serverUri, EndpointName, serializer: ObjectSerializer.SystemTextJson ) )
+		{ }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="OAuthServiceRestClient"/> class.
+		/// </summary>
+		/// <param name="settings">The settings of the rest service.</param>
+		internal OAuthServiceRestClient( RestClientSettings settings )
+			: base( new RestClient( EndpointName, settings ) )
 		{ }
 
 		#endregion

--- a/src/Api.Rest/HttpClient/RawData/RawDataServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/RawData/RawDataServiceRestClient.cs
@@ -22,13 +22,13 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
 	using Zeiss.PiWeb.Api.Rest.Common.Client;
+	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Common.Data;
 	using Zeiss.PiWeb.Api.Rest.Common.Data.FilterString.Formatter;
 	using Zeiss.PiWeb.Api.Rest.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;
 	using Zeiss.PiWeb.Api.Rest.Dtos.RawData;
 	using Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
-	using Zeiss.PiWeb.Api.Rest.HttpClient.Data;
 	using Zeiss.PiWeb.Api.Rest.HttpClient.RawData.Filter.Conditions;
 
 	#endregion
@@ -191,6 +191,9 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 
 		#region interface IRawDataServiceRestClient
 
+		/// <inheritdoc />
+		public ICustomRestClient CustomRestClient => _RestClient;
+
 		/// <summary>
 		/// Method for fetching the <see cref="ServiceInformationDto"/>. This method can be used for connection checking. The call returns quickly
 		/// and does not produce any noticeable server load.
@@ -223,14 +226,22 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 			}
 		}
 
-		/// <summary>
-		/// Method for fetching the <see cref="RawDataServiceFeatureMatrix"/>
-		/// </summary>
-		/// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public Task<RawDataServiceFeatureMatrix> GetFeatureMatrix( CancellationToken cancellationToken = default )
 		{
 			return GetFeatureMatrixInternal( FetchBehavior.FetchAlways, cancellationToken );
+		}
+
+		/// <inheritdoc />
+		public Task<RawDataServiceFeatureMatrix> GetFeatureMatrix(
+			RefreshPolicy refreshPolicy,
+			CancellationToken cancellationToken = default )
+		{
+			var fetchBehavior = refreshPolicy == RefreshPolicy.UseLatestResult
+				? FetchBehavior.FetchIfNotCached
+				: FetchBehavior.FetchAlways;
+
+			return GetFeatureMatrixInternal( fetchBehavior, cancellationToken );
 		}
 
 		/// <summary>

--- a/src/Api.Rest/HttpClient/RawData/RawDataServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/RawData/RawDataServiceRestClient.cs
@@ -27,6 +27,8 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 	using Zeiss.PiWeb.Api.Rest.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Dtos;
 	using Zeiss.PiWeb.Api.Rest.Dtos.RawData;
+	using Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
+	using Zeiss.PiWeb.Api.Rest.HttpClient.Data;
 	using Zeiss.PiWeb.Api.Rest.HttpClient.RawData.Filter.Conditions;
 
 	#endregion
@@ -38,7 +40,10 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 	{
 		#region constants
 
-		private const string EndpointName = "RawDataServiceRest/";
+		/// <summary>
+		/// The name of the endpoint of this service.
+		/// </summary>
+		public const string EndpointName = "RawDataServiceRest/";
 
 		#endregion
 
@@ -61,11 +66,22 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 			: base( restClient ?? new RestClient( serverUri, EndpointName, maxUriLength: maxUriLength, serializer: ObjectSerializer.SystemTextJson ) )
 		{ }
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RawDataServiceRestClient"/> class.
+		/// </summary>
+		/// <param name="settings">The settings of the rest service.</param>
+		internal RawDataServiceRestClient( RestClientSettings settings )
+			: base( new RestClient( EndpointName, settings ) )
+		{ }
+
 		#endregion
 
 		#region methods
 
-		private Task<RawDataInformationDto[]> ListRawDataForAllEntities( [NotNull] IFilterCondition filter, string requestPath, CancellationToken cancellationToken = default )
+		private Task<RawDataInformationDto[]> ListRawDataForAllEntities(
+			[NotNull] IFilterCondition filter,
+			string requestPath,
+			CancellationToken cancellationToken = default )
 		{
 			if( filter == null )
 				throw new ArgumentNullException( nameof( filter ) );

--- a/src/Api.Rest/HttpClient/RawData/RawDataServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/RawData/RawDataServiceRestClient.cs
@@ -22,7 +22,6 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.RawData
 	using System.Threading.Tasks;
 	using JetBrains.Annotations;
 	using Zeiss.PiWeb.Api.Rest.Common.Client;
-	using Zeiss.PiWeb.Api.Rest.Common.Contracts;
 	using Zeiss.PiWeb.Api.Rest.Common.Data;
 	using Zeiss.PiWeb.Api.Rest.Common.Data.FilterString.Formatter;
 	using Zeiss.PiWeb.Api.Rest.Contracts;


### PR DESCRIPTION
# Overview
This PR aims to improve the necessary code complexity for integrating the PiWeb-API in an import plugin. The major problem of the current PiWeb-API state is setting up non-interactive OAuth/OIDC authentication for a provided refresh token. Currently this requires deriving several classes to gain access to protected constructors, overriding protected methods and also manually implementing the OAuth/OIDC flow to gain access tokens.

There are also several minor obstacles that raise the necessary code complexity:
- Rest client constructors have too many parameters and need to be set up individually.
- Endpoint names are not public but required when deriving from rest clients leading to duplication of constants

The solutions I chose to implement are supposed to improve these problems not only specifically for import plugins but also for the general user of this API. The following improvements are introduced by this PR:

# New rest client builder
A new RestClientBuilder class enables configuring one or more rest clients using a fluent syntax. A number of settings can optionally be configured before actually creating the rest clients. Default values are assumed for any setting that is not configured. The only required setting is the server uri which has no sensible default value.
A simple example that uses only default settings:
```c#
var builder = new RestClientBuilder(uri);
var dataServiceRestClient = builder.CreateDataServiceRestClient();
var rawDataServiceRestClient = builder.CreateRawDataServiceRestClient();
```
This default configuration includes an http cache that is shared between all created rest clients. However, caching can easily be customized or even disabled completely (useful for debugging):
```c#
// Use externally managed caches
var cacheStore = new InMemoryCacheStore();
var varyHeaderStore = new InMemoryVaryHeaderStore();
var builder = new RestClientBuilder(uri)
    .EnableExternalHttpCaching(cacheStore, varyHeaderStore);
```
```c#
// Disable any http caching
var builder = new RestClientBuilder(uri)
    .DisableHttpCaching();
```
The builder provides access to all existing configuration settings, even to some that previously required deriving classes to access protected constructors:
```c#
var builder = new RestClientBuilder(uri)
    .SetTimeout(TimeSpan.FromSeconds(3))
    .SetMaxUriLength(4000)
    .SetAllowChunkedTransferEncoding(false)
    .SetMaxRequestsInParallel(10)
    .SetUseSystemHttpProxy(false)
    .DisableHttpCaching();
```
Finally, the builder also adds some convenience for specifying default values like timeouts:
```c#
var builder = new RestClientBuilder(uri)
    .SetStandardTimeout(StandardTimeoutType.ConnectionCheck);
```
The builder exposes a public method to compile the complete configuration as a single structure. Using this, it is easily possible to extend the builder via extension methods to create rest client types not directly included in the PiWeb-API.
All fluent configuration methods are virtual. If necessary, this enables deriving from RestClientBuilder and still keeping the fluent syntax with moderate effort.

# DelegatingHandler
DelegatingHandlers are very useful to inject behavior into the underlying HttpClient. For example a DelegatingHandler can be used to inject debug logging for http requests and responses. Other use cases include custom http caching implementations and authentication. Previousely, adding a DelegatingHandler to our rest clients involved using a protected constructor and was limited to a single DelegatingHandler. Setting a new AuthenticationContainer afterwards may even break the rest client because a new HttpClient will be instantiated under some circumstances and DelegatingHandlers do not support reassignment of inner handlers after their first handled http request. Using the new rest client builder, as many DelegatingHandlers as necessary may be added.
```c#
var builder = new RestClientBuilder(uri)
    .DisableHttpCaching()
    .AddDelegatingHandlerFactory(() => new CachingHandler())
    .AddDelegatingHandlerFactory(() => new LoggingHandler());
```
Since these DelegatingHandlers are specified as factory methods, we can build a separate chain per HttpClient instance. This solves the problem of setting new AuthenticationContainers and also allows us to create multiple rest clients from the same builder.

# Authentication
Previously any non static authentication mechanism required deriving from RestClient and overriding several methods. Using the custom RestClient derivation then required using protected constructors elsewhere. To make custom authentication easier to implement, it is now injectable via the IAuthenticationHandler interface. Authentication handlers can be added to a rest client builder:
```c#
var authenticationHandler = NonInteractiveAuthenticationHandler.Basic(authData.Username, authData.Password);
var restClient = new RestClientBuilder(uri)
    .SetAuthenticationHandler(authenticationHandler)
    .CreateDataServiceRestClient();
```
Authentication handlers may either choose to modify a request before it is send or modify the AuthenticationContainer of the corresponding rest client. They may also decide to retry a failed http request. Since communication between a rest client and its authentication handler only takes place via a context object, this can easily be extended in the future without breaking existing code using the PiWeb-API.
A NonInteractiveAuthenticationHandler is included that can handle non-interactive but not necessarily static authentication flows as required for example by import plugins:
```c#
var authenticationHandler = authData.AuthType switch
{
    AuthType.Basic => NonInteractiveAuthenticationHandler.Basic(authData.Username, authData.Password),
    AuthType.WindowsSSO => NonInteractiveAuthenticationHandler.WindowsSSO(),
    AuthType.Certificate => NonInteractiveAuthenticationHandler.Certificate(authData.CertificateThumbprint),
    AuthType.OIDC => NonInteractiveAuthenticationHandler.OIDC(authData.ReadAndUpdateRefreshTokenAsync),
    _ => null
};
```
In the future we may want to provide interactive IAuthenticationHandler implementations which ask the user for credentials. Because these likely will have UI framework dependencies, we would provide those as separate platform specific extension NuGets. The IAuthenticationHandler abstraction enables us to do this.

# Custom Rest Requests
Previously adding more rest requests to DataServiceRestClient or RawDataServiceRestClient (for example for specific API not directly provided with PiWeb-API) required derving these classes. Both clients now provide a ICustomRestClient instance via public property which enables implementing custom rest requests as extension methods on DataServiceRestClient and RawDataServiceRestClient. Since the correct service version is often needed to implement custom rest requests, a cached InterfaceVersion instance can now be aquired via public method as well so that constant refetching of the interface version can be avoided.