### PR TITLE
feat: Use action to build and deploy Github Pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,12 @@
+# Workflow to build and deploy the API documentation using GitHub Pages
+
+name: Build and deploy Github Pages
+
+on:
+  push:
+    branches: [ gh-pages ]
+
+jobs:
+  build-and-deploy-pages:
+    uses: ZEISS-PiWeb/github-actions/.github/workflows/deploy-gh-pages.yml@main
+    secrets: inherit


### PR DESCRIPTION
Uses action from https://github.com/ZEISS-PiWeb/github-actions/pull/35 to build and deploy the API documentation using GitHub Pages.