### PR TITLE
feature: support HTTP/3 and HTTP/2

### DIFF
--- a/src/Api.Rest/Common/Client/RestClientBase.cs
+++ b/src/Api.Rest/Common/Client/RestClientBase.cs
@@ -719,8 +719,13 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 			_HttpClient = new HttpClient( outerMostHandler )
 			{
 				Timeout = System.Threading.Timeout.InfiniteTimeSpan,
-				BaseAddress = ServiceLocation
+				BaseAddress = ServiceLocation,
+#if NET6_0_OR_GREATER
+				// support HTTP/3 and HTTP/2 and HTTP/1.1
+				DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
+#endif
 			};
+
 		}
 
 #if NET5_0_OR_GREATER

--- a/src/Api.Rest/Common/Utilities/OAuthHelper.cs
+++ b/src/Api.Rest/Common/Utilities/OAuthHelper.cs
@@ -205,7 +205,13 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Utilities
 			if( tokenResponse.IsError )
 				return null;
 
-			using var httpClient = new HttpClient();
+			using var httpClient = new HttpClient
+			{
+#if NET6_0_OR_GREATER
+				// support HTTP/3 and HTTP/2 and HTTP/1.1
+				DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
+#endif
+			};
 			var response = await httpClient
 				.GetUserInfoAsync( new UserInfoRequest { Address = userInfoEndpoint, Token = tokenResponse.AccessToken } )
 				.ConfigureAwait( false );
@@ -261,7 +267,13 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Utilities
 
 		private static string CreateOAuthStartUrl( string authorizeEndpoint, CryptoNumbers cryptoNumbers, OAuthTokenInformation tokenInformation )
 		{
-			using var httpClient = new HttpClient();
+			using var httpClient = new HttpClient
+			{
+#if NET6_0_OR_GREATER
+				// support HTTP/3 and HTTP/2 and HTTP/1.1
+				DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
+#endif
+			};
 
 			var request = new RequestUrl( authorizeEndpoint );
 			return request.CreateAuthorizeUrl(
@@ -300,7 +312,13 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Utilities
 
 		private static TokenClient CreateTokenClient( string tokenEndpoint, string clientId )
 		{
-			var tokenClient = new HttpClient();
+			var tokenClient = new HttpClient
+			{
+#if NET6_0_OR_GREATER
+				// support HTTP/3 and HTTP/2 and HTTP/1.1
+				DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher
+#endif
+			};
 			return new TokenClient( tokenClient, new TokenClientOptions
 			{
 				Address = tokenEndpoint,


### PR DESCRIPTION
The current implementation uses the default configuration of an HTTPClient in terms of HTTP protocol version and version policy. Which means, default version is HTTP1.1 and Policy is "RequestVersionOrLower". As a result, it will always use HTTP1.1 and never tries newer protocol version.

This PR changes the version policy to try/support all http protocol versions in the following order: HTTP/3, HTTP/2 and HTTP/1.1