### PR TITLE
Add ReportManagementServiceRestClient for querying report metadata

### DIFF
--- a/src/Api.Rest.Dtos/ReportManagement/LinkDto.cs
+++ b/src/Api.Rest.Dtos/ReportManagement/LinkDto.cs
@@ -1,0 +1,36 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.ReportManagement
+{
+
+	#region usings
+
+	using System.Text.Json.Serialization;
+
+	#endregion
+
+	/// <summary>
+	/// Contains the description of a link.
+	/// </summary>
+	public class LinkDto
+	{
+		#region properties
+
+		/// <summary>
+		/// Gets the Url of the link.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "href" )]
+		[JsonPropertyName( "href" )]
+		public string Href { get; set; }
+
+		#endregion
+	}
+}

--- a/src/Api.Rest.Dtos/ReportManagement/ReportMetadataDto.cs
+++ b/src/Api.Rest.Dtos/ReportManagement/ReportMetadataDto.cs
@@ -1,0 +1,170 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.ReportManagement
+{
+
+	#region usings
+
+	using System;
+	using System.Text.Json.Serialization;
+
+	#endregion
+
+	/// <summary>
+	/// Contains the report metadata.
+	/// </summary>
+	public sealed class ReportMetadataDto
+	{
+		#region properties
+
+		/// <summary>
+		/// Gets the unique identifier of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "uuid" )]
+		[JsonPropertyName( "uuid" )]
+		public Guid Uuid { get; set; }
+
+		/// <summary>
+		/// Gets the unique identifier of the report directory.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "directoryUuid" )]
+		[JsonPropertyName( "directoryUuid" )]
+		public Guid DirectoryUuid { get; set; }
+
+		/// <summary>
+		/// Gets the file name of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "fileName" )]
+		[JsonPropertyName( "fileName" )]
+		public string FileName { get; set; }
+
+		/// <summary>
+		/// Gets the user UUID of the user who  setially uploaded the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "creator" )]
+		[JsonPropertyName( "creator" )]
+		public Guid Creator { get; set; }
+
+		/// <summary>
+		/// Gets the creation time (UTC) of the report metadata, which is the  setial upload time of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "created" )]
+		[JsonPropertyName( "created" )]
+		public DateTime Created { get; set; }
+
+		/// <summary>
+		/// Gets the user UUID of the user who uploaded the report the last time.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "lastModifier" )]
+		[JsonPropertyName( "lastModifier" )]
+		public Guid LastModifier { get; set; }
+
+		/// <summary>
+		///Gets the last modification time (UTC) of the report metadata.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "lastModified" )]
+		[JsonPropertyName( "lastModified" )]
+		public DateTime LastModified { get; set; }
+
+		/// <summary>
+		/// Gets the user UUID of the user who deleted the report or <see langword="null"/> if the report is not deleted.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "deleter" )]
+		[JsonPropertyName( "deleter" )]
+		public Guid? Deleter { get; set; }
+
+		/// <summary>
+		/// Gets the deletion time (UTC) of the report metadata or <see langword="null"/> if the report is not deleted.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "deleted" )]
+		[JsonPropertyName( "deleted" )]
+		public DateTime? Deleted { get; set; }
+
+		/// <summary>
+		/// Gets the file size of the report in bytes.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "size" )]
+		[JsonPropertyName( "size" )]
+		public long Size { get; set; }
+
+		/// <summary>
+		/// Gets the checksum of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "mD5" )]
+		[JsonPropertyName( "mD5" )]
+		public Guid? MD5 { get; set; }
+
+		/// <summary>
+		/// Gets the version of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "version" )]
+		[JsonPropertyName( "version" )]
+		public Version Version { get; set; }
+
+		/// <summary>
+		/// Gets the display name of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "displayName" )]
+		[JsonPropertyName( "displayName" )]
+		public string DisplayName { get; set; }
+
+		/// <summary>
+		/// Gets the description of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "description" )]
+		[JsonPropertyName( "description" )]
+		public string Description { get; set; }
+
+		/// <summary>
+		/// Gets the group of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "reportGroup" )]
+		[JsonPropertyName( "reportGroup" )]
+		public string ReportGroup { get; set; }
+
+		/// <summary>
+		/// Gets the creator of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "reportCreator" )]
+		[JsonPropertyName( "reportCreator" )]
+		public string ReportCreator { get; set; }
+
+		/// <summary>
+		/// Gets the creation time of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "reportCreated" )]
+		[JsonPropertyName( "reportCreated" )]
+		public DateTime ReportCreated { get; set; }
+
+		/// <summary>
+		/// Gets the last modifier of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "reportLastModifier" )]
+		[JsonPropertyName( "reportLastModifier" )]
+		public string ReportLastModifier { get; set; }
+
+		/// <summary>
+		/// Gets the last modification time of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "reportLastModified" )]
+		[JsonPropertyName( "reportLastModified" )]
+		public DateTime ReportLastModified { get; set; }
+
+		/// <summary>
+		/// Gets the links to further endpoints of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "links" )]
+		[JsonPropertyName( "links" )]
+		public ReportMetadataLinksDto Links { get; set; }
+
+		#endregion
+	}
+}

--- a/src/Api.Rest.Dtos/ReportManagement/ReportMetadataLinksDto.cs
+++ b/src/Api.Rest.Dtos/ReportManagement/ReportMetadataLinksDto.cs
@@ -1,0 +1,50 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Dtos.ReportManagement
+{
+
+	#region usings
+
+	using System.Text.Json.Serialization;
+
+	#endregion
+
+	/// <summary>
+	/// Contains further links to endpoints of the report.
+	/// </summary>
+	public class ReportMetadataLinksDto
+	{
+		#region properties
+
+		/// <summary>
+		/// Gets the link to the ReportMetadata endpoint of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "self" )]
+		[JsonPropertyName( "self" )]
+		public LinkDto Self { get; set; }
+
+		/// <summary>
+		/// Gets the link to the thumbnail endpoint of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "thumbnail" )]
+		[JsonPropertyName( "thumbnail" )]
+		public LinkDto Thumbnail { get; set; }
+
+		/// <summary>
+		/// Gets the link to the content endpoint of the report.
+		/// </summary>
+		[Newtonsoft.Json.JsonProperty( "content" )]
+		[JsonPropertyName( "content" )]
+		public LinkDto Content { get; set; }
+
+		#endregion
+	}
+}

--- a/src/Api.Rest.Dtos/WHATSNEW.txt
+++ b/src/Api.Rest.Dtos/WHATSNEW.txt
@@ -1,0 +1,1 @@
+﻿- Add ReportManagement Dtos to be used in the ReportManagementServiceRestClient

--- a/src/Api.Rest.Tests/HttpClient/ReportManagement/ReportManagementServiceRestClientTest.cs
+++ b/src/Api.Rest.Tests/HttpClient/ReportManagement/ReportManagementServiceRestClientTest.cs
@@ -1,0 +1,128 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Tests.HttpClient.ReportManagement
+{
+	#region usings
+
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Threading.Tasks;
+	using FluentAssertions;
+	using Newtonsoft.Json;
+	using NUnit.Framework;
+	using Zeiss.PiWeb.Api.Rest.Dtos.ReportManagement;
+	using Zeiss.PiWeb.Api.Rest.HttpClient.ReportManagement;
+
+	#endregion
+
+	[TestFixture]
+	public class ReportManagementServiceRestClientTest
+	{
+		#region constants
+
+		private const int Port = 8081;
+
+		#endregion
+
+		#region members
+
+		private static readonly Uri Uri = new Uri( $"http://localhost:{Port}/" );
+
+		#endregion
+
+		#region methods
+
+		[Test]
+		[TestCase(true)]
+		[TestCase(false)]
+		[TestCase(null)]
+		public async Task GetReportMetadataListAsync_NoMetadata_ReturnEmptyEnumerable(bool?  deleted)
+		{
+			using var webServer = WebServer.StartNew( Port );
+			RegisterReportManagementReportMetadataResponse( webServer, deleted, [] );
+
+			using var sut = new ReportManagementServiceRestClient( Uri );
+			var actual = await sut.GetReportMetadataList( deleted );
+
+			actual.Count.Should().Be( 0 );
+		}
+
+		[Test]
+		[TestCase(true)]
+		[TestCase(false)]
+		[TestCase(null)]
+		public async Task GetReportMetadataListAsync_MetaDataAvailable_ReturnsCorrectNumberOfDtos(bool? deleted)
+		{
+			using var webServer = WebServer.StartNew( Port );
+			RegisterReportManagementReportMetadataResponse( webServer, deleted, [new ReportMetadataDto(), new ReportMetadataDto()] );
+
+			using var sut = new ReportManagementServiceRestClient( Uri );
+			var actual = await sut.GetReportMetadataList( deleted);
+
+			actual.Count.Should().Be( 2 );
+		}
+
+		[Test]
+		[TestCase(true)]
+		[TestCase(false)]
+		[TestCase(null)]
+		public async Task GetReportMetadataListAsync_MetaDataAvailable_ReturnsCorrectMetadata(bool? deleted)
+		{
+			using var webServer = WebServer.StartNew( Port );
+			var availableMetadata = new ReportMetadataDto
+			{
+				Uuid = Guid.NewGuid(),
+				DirectoryUuid = Guid.NewGuid(),
+				FileName = "Some File Name",
+				Creator = Guid.NewGuid(),
+				Created = DateTime.Now,
+				LastModifier = Guid.NewGuid(),
+				LastModified = DateTime.Now,
+				Deleter = null,
+				Deleted = null,
+				Size = 1337,
+				MD5 = Guid.NewGuid(),
+				Version = new Version( 8, 3, 5 ),
+				DisplayName = "Test Report",
+				Description = "This report exists for testing purposes.",
+				ReportGroup = "no group",
+				ReportCreator = "author",
+				ReportCreated = DateTime.Now,
+				ReportLastModifier = "no one",
+				ReportLastModified = DateTime.Now,
+				Links = new ReportMetadataLinksDto
+				{
+					Content = new LinkDto { Href = "ftp://content.com" },
+					Self = new LinkDto { Href = "https://self.com" },
+					Thumbnail = new LinkDto { Href = "https://self.com/thumbnail" }
+				}
+			};
+			RegisterReportManagementReportMetadataResponse( webServer, deleted, [availableMetadata] );
+
+			using var sut = new ReportManagementServiceRestClient( Uri );
+			var result = await sut.GetReportMetadataList( deleted);
+
+			var actual = result.FirstOrDefault();
+
+			JsonConvert.SerializeObject( availableMetadata ).Should().BeEquivalentTo( JsonConvert.SerializeObject( actual ) );
+		}
+
+		private static void RegisterReportManagementReportMetadataResponse( WebServer webServer, bool? deleted , ICollection<ReportMetadataDto> reports )
+		{
+			var url = $"/ReportManagementServiceRest/Reports{(deleted != null ? $"?deleted={deleted}" : "")}";
+			var responseJson = JsonConvert.SerializeObject( reports );
+			webServer.RegisterResponse( url, responseJson );
+		}
+
+		#endregion
+	}
+}

--- a/src/Api.Rest/Contracts/IReportManagementServiceRestClient.cs
+++ b/src/Api.Rest/Contracts/IReportManagementServiceRestClient.cs
@@ -1,0 +1,20 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Contracts
+{
+
+	/// <summary>
+	/// Web service interface to communicate with the REST based PiWeb report management service.
+	/// </summary>
+	public interface IReportManagementServiceRestClient : IReportManagementServiceRestClientBase<ReportManagementServiceFeatureMatrix>
+	{ }
+
+}

--- a/src/Api.Rest/Contracts/IReportManagementServiceRestClientBase.cs
+++ b/src/Api.Rest/Contracts/IReportManagementServiceRestClientBase.cs
@@ -1,0 +1,55 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Contracts
+{
+
+	#region usings
+
+	using System;
+	using System.Collections.Generic;
+	using System.IO;
+	using System.Threading;
+	using System.Threading.Tasks;
+	using Zeiss.PiWeb.Api.Rest.Dtos;
+	using Zeiss.PiWeb.Api.Rest.Dtos.ReportManagement;
+
+	#endregion
+
+	/// <summary>
+	/// Client class for communicating with the REST based report management service.
+	/// </summary>
+	public interface IReportManagementServiceRestClientBase<T> where T : ReportManagementServiceFeatureMatrix
+	{
+		#region properties
+
+		/// <summary>
+		/// A custom rest client that can be used to execute rest request created by a rest request builder.
+		/// </summary>
+		public ICustomRestClient CustomRestClient { get; }
+
+		#endregion
+
+		#region methods
+
+		/// <summary>
+		/// Retrieves a list of all reports.
+		/// </summary>
+		/// <param name="deleted">
+		/// <see langword="true" /> if the result should be restricted to deleted reports,
+		/// <see langword="false" /> if the result should be restricted to non-deleted reports,
+		/// <see langword="null" /> if the result should not be restricted regarding deletion.
+		/// </param>
+		/// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+		Task<IReadOnlyCollection<ReportMetadataDto>> GetReportMetadataList( bool? deleted, CancellationToken cancellationToken = default );
+
+		#endregion
+	}
+}

--- a/src/Api.Rest/Contracts/ReportManagementServiceFeatureMatrix.cs
+++ b/src/Api.Rest/Contracts/ReportManagementServiceFeatureMatrix.cs
@@ -1,0 +1,39 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.Contracts
+{
+
+	#region usings
+
+	using System;
+	using JetBrains.Annotations;
+	using Zeiss.PiWeb.Api.Rest.Dtos;
+
+	#endregion
+
+	/// <summary>
+	/// Provides the minimum server version for several features.
+	/// </summary>
+	public class ReportManagementServiceFeatureMatrix : FeatureMatrix
+	{
+		#region constructors
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ReportManagementServiceFeatureMatrix"/> class.
+		/// </summary>
+		/// <exception cref="ArgumentNullException"><paramref name="interfaceVersionRange"/> is <see langword="null" />.</exception>
+		public ReportManagementServiceFeatureMatrix( [NotNull] InterfaceVersionRange interfaceVersionRange ) : base( interfaceVersionRange )
+		{ }
+
+		#endregion
+
+	}
+}

--- a/src/Api.Rest/HttpClient/ReportManagement/ReportManagementServiceRestClient.cs
+++ b/src/Api.Rest/HttpClient/ReportManagement/ReportManagementServiceRestClient.cs
@@ -1,0 +1,82 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.HttpClient.ReportManagement
+{
+
+	#region usings
+
+	using System;
+	using System.Collections.Generic;
+	using System.Threading;
+	using System.Threading.Tasks;
+	using JetBrains.Annotations;
+	using Zeiss.PiWeb.Api.Rest.Common.Client;
+	using Zeiss.PiWeb.Api.Rest.Contracts;
+	using Zeiss.PiWeb.Api.Rest.Dtos;
+	using Zeiss.PiWeb.Api.Rest.Dtos.ReportManagement;
+	using Zeiss.PiWeb.Api.Rest.HttpClient.Builder;
+
+	#endregion
+
+	/// <summary>
+	/// Client class for communicating with the REST based report management service.
+	/// </summary>
+	public sealed class ReportManagementServiceRestClient : CommonRestClientBase, IReportManagementServiceRestClient
+	{
+		#region constants
+
+		/// <summary>
+		/// The name of the endpoint of this service.
+		/// </summary>
+		public const string EndpointName = "ReportManagementServiceRest/";
+
+		#endregion
+
+		#region constructors
+
+		/// <summary>
+		/// Constructor. Instantiates a new <see cref="ReportManagementServiceRestClient"/> to communicate with the PiWeb-Server ReportManagementServiceRest.
+		/// </summary>
+		/// <param name="serverUri">The PiWeb Server uri, including port and instance</param>
+		/// <param name="maxUriLength">The uri length limit</param>
+		/// <param name="restClient">Custom implementation of RestClient</param>
+		public ReportManagementServiceRestClient( [NotNull] Uri serverUri, int maxUriLength = RestClientBase.DefaultMaxUriLength, RestClientBase restClient = null )
+			: base( restClient ?? new RestClient( serverUri, EndpointName, maxUriLength: maxUriLength, serializer: ObjectSerializer.SystemTextJson ) )
+		{ }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ReportManagementServiceRestClient"/> class.
+		/// </summary>
+		/// <param name="settings">The settings of the rest service.</param>
+		internal ReportManagementServiceRestClient( RestClientSettings settings )
+			: base( new RestClient( EndpointName, settings ) )
+		{ }
+
+		#endregion
+
+		#region interface IReportManagementServiceRestClient
+
+		/// <inheritdoc />
+		public ICustomRestClient CustomRestClient => _RestClient;
+
+		/// <inheritdoc />
+		public Task<IReadOnlyCollection<ReportMetadataDto>> GetReportMetadataList( bool? deleted, CancellationToken cancellationToken = default )
+		{
+			return _RestClient.Request<IReadOnlyCollection<ReportMetadataDto>>(
+				deleted == null
+					? RequestBuilder.CreateGet( "Reports" )
+					: RequestBuilder.CreateGet( "Reports", ParameterDefinition.Create( "deleted", deleted.Value.ToString() ) ),
+				cancellationToken );
+		}
+
+		#endregion
+	}
+}

--- a/src/Api.Rest/WHATSNEW.txt
+++ b/src/Api.Rest/WHATSNEW.txt
@@ -1,0 +1,1 @@
+﻿- Add new HttpClient 'ReportManagementServiceRestClient' to interact with the /ReportManagementServiceRest/Reports endpoint.


### PR DESCRIPTION
Adds a new client for interacting with the /ReportManagementServiceRest endpoints needed for development  of other Zeiss software.
The client currently supports the following endpoints:
- /ReportManagementServiceRest/Reports

Since the endpoints are not part of the public I wasn't sure how the FeatureMatrix should be defined. Let me know if you have any suggestions.