### PR TITLE
(MAJOR) feat: Update target framework and dependencies

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -10,5 +10,5 @@ jobs:
   release:
     uses: ZEISS-PiWeb/github-actions/.github/workflows/create-release.yml@main
     with:
-      dotnet_version: "7.0.x"
+      dotnet_version: "8.0.x"
     secrets: inherit

--- a/.github/workflows/create-service-pack.yml
+++ b/.github/workflows/create-service-pack.yml
@@ -57,5 +57,5 @@ jobs:
       is_prerelease: false
       suffix: "stable"
       publish_target: "nuget.org"
-      dotnet_version: "7.0.x"
+      dotnet_version: "8.0.x"
     secrets: inherit

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -13,5 +13,5 @@ jobs:
     uses: ZEISS-PiWeb/github-actions/.github/workflows/develop.yml@main
     with:
       do_pack: true
-      dotnet_version: "7.0.x"
+      dotnet_version: "8.0.x"
     secrets: inherit

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -11,5 +11,5 @@ jobs:
     uses: ZEISS-PiWeb/github-actions/.github/workflows/feature-branch.yml@main
     with:
       do_pack: true  
-      dotnet_version: "7.0.x"
+      dotnet_version: "8.0.x"
     secrets: inherit

--- a/src/Api.Core/Api.Core.csproj
+++ b/src/Api.Core/Api.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  	<TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+  	<TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Zeiss.PiWeb.Api.Core</RootNamespace>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -49,9 +49,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.8" />
-    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.8" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Api.Definitions/Api.Definitions.csproj
+++ b/src/Api.Definitions/Api.Definitions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  	<TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+  	<TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Zeiss.PiWeb.Api.Definitions</RootNamespace>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Api.Rest.Dtos.Tests/Api.Rest.Dtos.Tests.csproj
+++ b/src/Api.Rest.Dtos.Tests/Api.Rest.Dtos.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Zeiss.PiWeb.Api.Rest.Dtos.Tests</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Zeiss.PiWeb.Api.Rest.Dtos.Tests</AssemblyName>
@@ -15,7 +15,7 @@
         <PackageReference Include="FluentAssertions" Version="6.11.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.0" />
+        <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.3.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
             <PrivateAssets>all</PrivateAssets>

--- a/src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
+++ b/src/Api.Rest.Dtos/Api.Rest.Dtos.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <RootNamespace>Zeiss.PiWeb.Api.Rest.Dtos</RootNamespace>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -50,10 +50,10 @@
     </ItemGroup>
 
     <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
-    <PackageReference Include="SauceControl.InheritDoc" Version="1.3.0">
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="SauceControl.InheritDoc" Version="1.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Api.Rest.Tests/Api.Rest.Tests.csproj
+++ b/src/Api.Rest.Tests/Api.Rest.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <RootNamespace>Zeiss.PiWeb.Api.Rest.Tests</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Zeiss.PiWeb.Api.Rest.Tests</AssemblyName>

--- a/src/Api.Rest/Api.Rest.csproj
+++ b/src/Api.Rest/Api.Rest.csproj
@@ -5,7 +5,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <RootNamespace>Zeiss.PiWeb.Api.Rest</RootNamespace>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageVersion>8.3.1</PackageVersion>
   </PropertyGroup>
@@ -54,20 +54,20 @@
   </ItemGroup>
 
   <ItemGroup Label="NuGet references">
-    <PackageReference Include="CacheCow.Client" Version="2.12.1" />
-    <PackageReference Include="IdentityModel" Version="6.1.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2020.3.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="6.34.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.34.0" />
+    <PackageReference Include="CacheCow.Client" Version="2.13.1" />
+    <PackageReference Include="IdentityModel" Version="6.2.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Logging" Version="8.0.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
-    <PackageReference Include="SauceControl.InheritDoc" Version="1.3.0">
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="SauceControl.InheritDoc" Version="1.4.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.34.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="7.0.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.2" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Update target frameworks:**
- remove .NET 7
- add .NET 8

**Update dependencies:**
_Api.Definitions:_
- JetBrains.Annotations from 2020.3.0 to 2024.2.0

_Api.Core:_
- JetBrains.Annotations from 2020.3.0 to 2024.2.0
- Microsoft.Extensions.ObjectPool from 7.0.8 to 8.0.8
- CommunityToolkit.HighPerformance 8.2.0 to 8.3.0

_Api.Rest.Dtos:_
- JetBrains.Annotations from 2020.3.0 to 2024.2.0
- System.Text.Json from 7.0.3 to 8.0.4
- SauceControl.InheritDoc 1.3.0 to 1.4.0

_Api.Rest:_
- JetBrains.Annotations from 2020.3.0 to 2024.2.0
- CacheCow.Client from 2.12.1 to 2.13.1
- IdentityModel from 6.2.0 to 7.0.0
- Microsoft.IdentityModel.Logging from 6.34.0 to 8.0.2
- Microsoft.IdentityModel.Tokens from 6.34.0 to 8.0.2
- System.Text.Json from 7.0.3 to 8.0.4
- System.IdentityModel.Tokens.Jwt from 6.34.0 to 8.0.2
- System.Security.Cryptography.ProtectedData 7.0.1 to 8.0.0