### PR TITLE
fix: Recognize backslash at end of path as part of name

### DIFF
--- a/src/Api.Core/PathHelper.cs
+++ b/src/Api.Core/PathHelper.cs
@@ -160,10 +160,42 @@ namespace Zeiss.PiWeb.Api.Core
 				path = DelimiterString + path;
 
 			// convert to database format by appending a delimiter if it is not already present (beware of escaping)
-			if( !path.EndsWith( DelimiterString, StringComparison.Ordinal ) || path.EndsWith( EscapedDelimiter, StringComparison.Ordinal ) )
+			if(!EndsWithDelimiter( path ))
 				path += DelimiterString;
 
 			return String2PathInformationInternal( path.AsSpan(), "".AsSpan(), stringPool, entity );
+		}
+
+		/// <summary>
+		/// Checks whether the path string already contains a delimiter at the end.
+		/// </summary>
+		private static bool EndsWithDelimiter( string path )
+		{
+			var isEscaped = false;
+			var hasDelimiter = false;
+
+			foreach( var character in path )
+			{
+				switch( character )
+				{
+					case Escape when !isEscaped:
+						isEscaped = true;
+						hasDelimiter = false;
+						continue;
+					case Delimiter:
+					{
+						if( !isEscaped )
+							hasDelimiter = true;
+						break;
+					}
+					default:
+						hasDelimiter = false;
+						break;
+				}
+
+				isEscaped = false;
+			}
+			return hasDelimiter;
 		}
 
 		/// <summary>

--- a/src/Api.Rest.Dtos.Tests/PathHelperTests.cs
+++ b/src/Api.Rest.Dtos.Tests/PathHelperTests.cs
@@ -127,6 +127,30 @@ namespace Zeiss.PiWeb.Api.Rest.Dtos.Tests
 		}
 
 		[Test]
+		public void String2PartPathInformation_PathEndsWithBackslash_ReturnsPathInformationDto()
+		{
+			const string path = "Bad\\\\/";
+			var result = PathHelper.String2PartPathInformation( path );
+			Assert.AreEqual( result, new PathInformation(new PathElement(value: "Bad\\")) );
+		}
+
+		[Test]
+		public void String2PartPathInformation_PathEndsWithSlash_ReturnsPathInformationDto()
+		{
+			const string path = "Bad\\/";
+			var result = PathHelper.String2PartPathInformation( path );
+			Assert.AreEqual( result, new PathInformation(new PathElement(value: "Bad/")) );
+		}
+
+		[Test]
+		public void String2PartPathInformation_PathEndsWithSlashAndBackslash_ReturnsPathInformationDto()
+		{
+			const string path = "Bad\\/\\\\";
+			var result = PathHelper.String2PartPathInformation( path );
+			Assert.AreEqual( result, new PathInformation(new PathElement(value: "Bad/\\")) );
+		}
+
+		[Test]
 		public void String2CharPathInformation_PathIsEmpty_ThrowsException()
 		{
 			Assert.Throws<ArgumentException>( () => PathHelper.String2CharPathInformation( string.Empty ) );


### PR DESCRIPTION
This PR improves recognition of delimiters at the end of paths which fixes a bug that occurred when creating and fetching a part which ended with a backslash.