### PR TITLE
fix: Extended documentation for the CheckAttributeUsage endpoint

### DIFF
--- a/_pages/API/1.11/DataService/023-dataservice-configuration.md
+++ b/_pages/API/1.11/DataService/023-dataservice-configuration.md
@@ -183,11 +183,20 @@ HTTP/1.1 200 Ok
 {% assign method="GET" %}
 {% assign endpoint="/attributes/:key/:value" %}
 {% assign summary="Checks if at least an attribute with :key and :value exists" %}
-{% assign description="If at least one entry with value for the given key exists HTTP status code 204 otherwise 404 is returned." %}
+{% assign description="If at least one entry with value for the given key exists HTTP status code 204 otherwise 404 is returned. <br/><br/> Remarks: The `:value` can be wrapped in quotation marks once, any additional quotation marks will be treated as part of the `:value`." %}
 
-{% assign exampleCaption="" %}
-{% assign jsonrequest="" %}
-{% assign jsonresponse="" %}
+{% assign exampleCaption="Check for attribute usages of the attribute with key `9` and value `Name`" %}
+{% capture jsonrequest %}
+{% highlight http %}
+GET /dataServiceRest/attributes/9/"Name" HTTP/1.1
+{% endhighlight %}
+{% endcapture %}
+
+{% capture jsonresponse %}
+{% highlight http %}
+HTTP/1.1 204 No Content
+{% endhighlight %}
+{% endcapture %}
 
 {% include endpointTab.html %}
 


### PR DESCRIPTION
This PR extends the documentation for the ```CheckAttributeUsage``` endpoint with an explanation for the new behavior regarding wrapping the attribute value in quotation marks.