### PR TITLE
Doc: Update documentation for 9.0.0 release

### DIFF
--- a/_pages/API/01-general.md
+++ b/_pages/API/01-general.md
@@ -163,7 +163,7 @@ The base address is:
 http(s)://serverHost:port/instanceName/DataServiceRest
 ```
 
-For further information see the [DataService documentation](http://zeiss-piweb.github.io/PiWeb-Api/dataservice/v1.10/ "Data Service documentation")
+For further information see the [DataService documentation](http://zeiss-piweb.github.io/PiWeb-Api/dataservice/v1.11/ "Data Service documentation")
 
 #### Raw Data Service
 Use the RawDataService to fetch, create, update and delete additional data, i.e. raw data. <br>

--- a/_pages/API/1.10/DataService/02-dataservice.md
+++ b/_pages/API/1.10/DataService/02-dataservice.md
@@ -4,7 +4,7 @@ level: 0
 version: 110
 displayVersion: "1.10"
 title: Data Service
-isCurrentVersion: true
+isCurrentVersion: false
 permalink: /dataservice/v1.10/
 sections:
   dataservice:

--- a/_pages/API/1.11/DataService/02-dataservice.md
+++ b/_pages/API/1.11/DataService/02-dataservice.md
@@ -4,7 +4,7 @@ level: 0
 version: 111
 displayVersion: "1.11"
 title: Data Service
-isCurrentVersion: false
+isCurrentVersion: true
 permalink: /dataservice/v1.11/
 sections:
   dataservice:

--- a/_pages/API/1.11/DataService/02-dataservice.md
+++ b/_pages/API/1.11/DataService/02-dataservice.md
@@ -33,6 +33,9 @@ sections:
       measurementsAndValues:
         title: Measurements and Values
         anchor: ds-measurements-and-values
+      events:
+        title: Events
+        anchor: ds-events
 ---
 
 {% include version_combobox.html %}
@@ -52,3 +55,5 @@ sections:
 {% include_relative 025-dataservice-inspectionplan.md %}
 
 {% include_relative 026-dataservice-measurementsandvalues.md %}
+
+{% include_relative 028-dataservice-events.md %}

--- a/_pages/API/1.11/DataService/020-dataservice-releasenotes.md
+++ b/_pages/API/1.11/DataService/020-dataservice-releasenotes.md
@@ -5,7 +5,9 @@
 {% assign version="1.11.0" %}
 {% capture features %}
     <ul>
-        <li>Coming soon.</li>
+        <li>Added endpoint to fetch the number of parts at a certain path or depth</li>
+        <li>Added endpoint to fetch the number of characteristics at a certain path or depth</li>
+        <li>Added endpoint to subscribe to <a href="/PiWeb-Api/dataservice/v1.11/#ds-events">events</a> of DataService activity</li>
     </ul>
 {% endcapture %}
 

--- a/_pages/API/1.11/DataService/021-dataservice-interfaceinformation.md
+++ b/_pages/API/1.11/DataService/021-dataservice-interfaceinformation.md
@@ -29,4 +29,4 @@ GET /dataServiceRest/ HTTP/1.1
 <h3 id="{{page.sections['interfaceInformation']['secs']['interfaceinformation'].anchor}}-objectstructure">Object Structure</h3>
 
 Interface information returns the highest available minor version of each major version. This lets the user decide which features can be used.
-As a minor version is backwards compatible to all previous minor versions, there is no point in enumerating them all. An user want to know which revision of each major version is available as that means they can work around possible bugs of older revisions.
+As a minor version is backwards compatible to all previous minor versions, there is no point in enumerating them all. A user wants to know which revision of each major version is available as that means they can work around possible bugs of older revisions.

--- a/_pages/API/1.11/DataService/025-dataservice-inspectionplan.md
+++ b/_pages/API/1.11/DataService/025-dataservice-inspectionplan.md
@@ -191,6 +191,8 @@ If you update a part you might want to:
 
 If versioning is activated on the server side, every update creates a new version entry. You should add a value for `comment` to explain why it was changed and by whom.
 The optimal format is "[Username]:Reason of change", e.g. "[John Doe]: Renamed 'Part1' to 'Part2'". This way it will be correctly displayed in PiWeb Planner.
+Please note that the JSON property `comment` can be added to different parts of the PUT request, however only one will be used by the PiWeb Server for the version entry.
+The `comment` of the first entry with actual changes will be used.
 
 {{site.images['info']}} If versioning is set to 'Controlled by the client' on server side it can be controlled by the following parameter:
 
@@ -378,7 +380,7 @@ Parameter name                                                                 |
 -------------------------------------------------------------------------------|--------------------------------
 <nobr><code>Guid list</code> charUuids<br></nobr>                              | Restricts the query to the characteristics with these uuids.
 <nobr><code>Path</code> partPath</nobr><br><i>default:</i> <code>/</code>      | Restricts the query to the part with this path. The <code>charUuids</code> parameter takes precedence over this parameter.
-<nobr><code>ushort</code> depth</nobr><br><i>default:</i> <code>65.536</code>  | Determines how many levels of the inspection plan tree hierarchy should be fetched. Setting `depth=0` means that only the entity itself should be fetched, `depth=1` means the entity and its direct children should be fetched. Please note that depth is treated relative of the path depth of the provided part or characteristic.
+<nobr><code>ushort</code> depth</nobr><br><i>default:</i> <code>65.535</code>  | Determines how many levels of the inspection plan tree hierarchy should be fetched. Setting `depth=0` means that only the entity itself should be fetched, `depth=1` means the entity and its direct children should be fetched. Please note that depth is treated relative of the path depth of the provided part or characteristic.
 <nobr><code>bool</code> withHistory</nobr><br><i>default:</i> <code>false</code>| Determines whether the version history should be fetched or not. This only effects the query if versioning is activated on the server side.
 <nobr><code>All, None, ID list</code> requestedCharacteristicAttributes</nobr><br><i>default:</i> <code>All</code>                                                                                  | Restricts the query to the attributes that should be returned for characteristics, for example `requestedCharacteristicAttributes={2001, 2101}`
 {% endcapture %}
@@ -536,6 +538,8 @@ If you update characteristics you want to:
 
 If versioning is activated on the server side, every update creates a new version entry. You should add a value for `comment` to explain why it was changed and by whom.
 The optimal format is "[Username]:Reason of change", e.g. "[John Doe]: Renamed 'Characteristic1' to 'Characteristic2'". This way it will be correctly displayed in PiWeb Planner.
+Please note that the JSON property `comment` can be added to different characteristics of the PUT request, however only one will be used by the PiWeb Server for the version entry.
+The `comment` of the first entry with actual changes will be used.
 
 {{site.images['info']}} If versioning is set to 'Controlled by the client' on server side it can be controlled by the following parameter:
 

--- a/_pages/API/1.11/DataService/025-dataservice-inspectionplan.md
+++ b/_pages/API/1.11/DataService/025-dataservice-inspectionplan.md
@@ -319,6 +319,45 @@ HTTP/1.1 200 Ok
 
 {% include endpointTab.html %}
 
+{% assign linkId="inspectionPlanEndpointCountParts" %}
+{% assign method="GET" %}
+{% assign endpoint="/parts/count" %}
+{% assign summary="Get the count of parts" %}
+{% capture description %}
+Get the number of parts matching specified criteria.
+The result can be restricted by the following uri parameters:
+
+{% capture table %}
+Parameter name                                                                 | Description
+-------------------------------------------------------------------------------|--------------------------------
+<nobr><code>Guid list</code> partUuids<br></nobr>                              | Restricts the query to the parts with these uuids.
+<nobr><code>Path</code> partPath</nobr>                                        | Restricts the query to the part with this path.
+<nobr><code>ushort</code> depth</nobr><br><i>default:</i> <code>1</code>       | Determines how many levels of the inspection plan tree hierarchy should be fetched. Setting `depth=0` means that only the entity itself should be fetched, `depth=1` means the entity and its direct children should be fetched. Please note that depth is treated relative of the path depth of the provided part.
+{% endcapture %}
+{{ table | markdownify | replace: '<table>', '<table class="table table-inline">' }}
+
+{% endcapture %}
+
+{% assign exampleCaption="Count the parts under '/metal part' to a depth of 50" %}
+
+{% capture jsonrequest %}
+{% highlight http %}
+GET /dataServiceRest/parts/count?partPath=/metal%20part&depth=50 HTTP/1.1
+{% endhighlight %}
+{% endcapture %}
+
+{% capture jsonresponse %}
+{% highlight json %}
+
+{
+    "count": 4
+}
+
+{% endhighlight %}
+{% endcapture %}
+
+{% include endpointTab.html %}
+
 
 <p></p>
 
@@ -587,6 +626,45 @@ DELETE /dataServiceRest/characteristics/27e23a7c-dbe7-4863-8461-6abf7b03ddd7 HTT
 {% capture jsonresponse %}
 {% highlight http %}
 HTTP/1.1 200 Ok
+{% endhighlight %}
+{% endcapture %}
+
+{% include endpointTab.html %}
+
+{% assign linkId="inspectionPlanEndpointCountChars" %}
+{% assign method="GET" %}
+{% assign endpoint="/characteristics/count" %}
+{% assign summary="Get the count of characteristics" %}
+{% capture description %}
+Get the number of characteristics matching specified criteria.
+The result can be restricted by the following uri parameters:
+
+{% capture table %}
+Parameter name                                                                 | Description
+-------------------------------------------------------------------------------|--------------------------------
+<nobr><code>Guid list</code> charUuids<br></nobr>                              | Restricts the query to the characteristics with these uuids.
+<nobr><code>Path</code> partPath</nobr><br><i>default:</i> <code>/</code>      | Restricts the query to the part with this path. The <code>charUuids</code> parameter takes precedence over this parameter.
+<nobr><code>ushort</code> depth</nobr><br><i>default:</i> <code>65.535</code>  | Determines how many levels of the inspection plan tree hierarchy should be fetched. Setting `depth=0` means that only the entity itself should be fetched, `depth=1` means the entity and its direct children should be fetched. Please note that depth is treated relative of the path depth of the provided part or characteristic.
+{% endcapture %}
+{{ table | markdownify | replace: '<table>', '<table class="table table-inline">' }}
+
+{% endcapture %}
+
+{% assign exampleCaption="Count the characteristics under '/metal part' to a depth of 5" %}
+
+{% capture jsonrequest %}
+{% highlight http %}
+GET /dataServiceRest/characteristics/count?partPath=/metal%20part&depth=5 HTTP/1.1
+{% endhighlight %}
+{% endcapture %}
+
+{% capture jsonresponse %}
+{% highlight json %}
+
+{
+    "count": 87
+}
+
 {% endhighlight %}
 {% endcapture %}
 

--- a/_pages/API/1.11/DataService/027-dataservice-measurementsandvalues-primarymeasurementkey.md
+++ b/_pages/API/1.11/DataService/027-dataservice-measurementsandvalues-primarymeasurementkey.md
@@ -28,7 +28,7 @@ Please note that these are measurements from three different inspection plan par
 
 | **Full query:** | `/measurements?order=4 desc&limitResult=3` |
 |------------------|--------------------------------------------------------------------|
-| **orderBy** | `4` | 
+| **order** | `4` | 
 | **limitResult** | `3` | 
 
 

--- a/_pages/API/1.11/DataService/028-dataservice-events.md
+++ b/_pages/API/1.11/DataService/028-dataservice-events.md
@@ -1,0 +1,49 @@
+<h2 id="{{page.sections['dataservice']['secs']['events'].anchor}}">{{page.sections['dataservice']['secs']['events'].title}}</h2>
+
+The PiWeb Server offers functionality for clients to be asynchronously notified of certain events, e.g. creation of measurements, using [SignalR](https://learn.microsoft.com/en-us/aspnet/core/signalr/introduction). A C# sample application using the PiWeb Server events endpoint can be found in the [PiWeb-Training Project](https://github.com/ZEISS-PiWeb/PiWeb-Training?tab=readme-ov-file#piwebapi---events) on GitHub.<br>
+Information and tutorials for different client technologies like .NET, JavaScript or Java can be found in the [SignalR client documentation](https://learn.microsoft.com/en-us/aspnet/core/signalr/client-features?view=aspnetcore-8.0).
+
+<h3 id="{{page.sections['dataservice']['secs']['events'].anchor}}-endpoints">Endpoint</h3>
+
+The events endpoint can be found under the route `http(s)://serverHost:port/events`. The endpoint is not part of the DataServiceRest, since it is able to send events for other parts of PiWeb, e.g. the [RawDataServiceRest](https://zeiss-piweb.github.io/PiWeb-Api/rawdataservice/v1.8/#rs-events "RawDataServiceRest events documentation").
+
+<h3 id="{{page.sections['dataservice']['secs']['events'].anchor}}-objectstructure">Available Events</h3>
+
+The following listing contains all events available for the entities managed using the DataServiceRest as well as the provided information in the events.
+
+>{{ site.images['info'] }} You will only receive events for entities with corresponding permissions assigned to your user.
+
+#### Parts
+
+{% capture table %}
+Event Type      |  Property |  Description
+----------------|-----------------------------------------------------------------------------------
+Created         | <nobr><code>Guid</code> PartUuid <br></nobr> <nobr><code>Guid</code> ParentPartUuid</nobr> | The unique identifier of the newly created part. <br> The unique identifier of the parent part where the new part was added to. 
+Modified        | <code>Guid</code> PartUuid | The unique identifier of the modified part.
+Moved           | <code>Guid</code> PartUuid <br> <code>string</code> FromPath <br><br> <code>string</code> ToPath | The unique identifier of the moved part. <br> The source path where the part was located before movement or empty string if the client is not authorized for read access. <br> The target path where the part was moved to or empty string if the client is not authorized for read access.
+Deleted         | <code>Guid</code> PartUuid <br> <code>Guid</code> ParentPartUuid | The unique identifier of the deleted part. <br> The unique identifier of the parent part where the part was deleted from.
+{% endcapture %}
+{{ table | markdownify | replace: '<table>', '<table class="table table-inline">' }}
+
+#### Characteristics
+
+{% capture table %}
+Event Type      |  Property  |  Description
+----------------|-----------------------------------------------------------------------------------
+Created         | <nobr><code>Guid</code> CharacteristicUuid</nobr> <br> <code>Guid</code> ParentUuid | The unique identifier of the newly created characteristic. <br> The unique identifier of the parent inspection plan item (either a part or a characteristic) where the new characteristic was added to.
+Modified        | <code>Guid</code> CharacteristicUuid <br> <code>Guid</code> ParentPartUuid | The unique identifier of the moved characteristic. <br> The unique identifier of the parent part where the characteristic was modified. The parent part may not be the direct parent in the inspection plan tree, it is possible that the direct parent is a characteristic.
+Moved           | <code>Guid</code> CharacteristicUuid <br> <code>string</code> FromPath <br><br> <code>string</code> ToPath | The unique identifier of the moved characteristic. <br> The source path where the characteristic was located before movement or empty string if the client is not authorized for read access. <br> The target path where the characteristic was moved to or empty string if the client is not authorized for read access .
+Deleted         | <code>Guid</code> CharacteristicUuid <br> <code>Guid</code> ParentPartUuid | The unique identifier of the deleted characteristic <br> The unique identifier of the parent part where the characteristic was deleted from.
+{% endcapture %}
+{{ table | markdownify | replace: '<table>', '<table class="table table-inline">' }}
+
+#### Measurements
+
+{% capture table %}
+Event Type      |  Property  |  Description
+----------------|-----------------------------------------------------------------------------------
+Created         | <code>Guid</code> CharacteristicUuid <br> <code>Guid</code> MeasurementUuid | The unique identifier of the part where the new measurement was created. <br> The unique identifier of the newly created measurement.
+Modified        | <code>Guid</code> CharacteristicUuid <br> <code>Guid</code> MeasurementUuid | The unique identifier of the part where the measurement was modified. <br> The unique identifier of the modified measurement.
+Deleted         | <code>Guid</code> CharacteristicUuid <br> <code>Guid</code> MeasurementUuid | The unique identifier of the part where the measurement was deleted. <br> The unique identifier of the deleted measurement.
+{% endcapture %}
+{{ table | markdownify | replace: '<table>', '<table class="table table-inline">' }}

--- a/_pages/API/v1.8/RawDataService/03-rawdataservice.md
+++ b/_pages/API/v1.8/RawDataService/03-rawdataservice.md
@@ -27,6 +27,9 @@ sections:
       rawDataObjects:
         title: Raw Data Objects
         anchor: rs-raw-data-objects
+      events:
+        title: Events
+        anchor: rs-events
 ---
 
 {% include version_combobox.html %}
@@ -44,3 +47,5 @@ sections:
 {% include_relative 034-rawdataservice-rawdataobjects.md %}
 
 {% include_relative 035-rawdataservice-archivelookup.md %}
+
+{% include_relative 036-rawdataservice-events.md %}

--- a/_pages/API/v1.8/RawDataService/030-rawdataservice-releasenotes.md
+++ b/_pages/API/v1.8/RawDataService/030-rawdataservice-releasenotes.md
@@ -6,6 +6,7 @@
 {% capture features %}
     <ul>
       <li>Internal optimizations for PiWeb clients.</li>
+      <li>Added endpoint to subscribe to <a href="/PiWeb-Api/rawdataservice/v1.8/#rs-events">events</a> of RawDataService activity</li>
     </ul>
 {% endcapture %}
 

--- a/_pages/API/v1.8/RawDataService/031-rawdataservice-interfaceinformation.md
+++ b/_pages/API/v1.8/RawDataService/031-rawdataservice-interfaceinformation.md
@@ -29,4 +29,4 @@ GET /rawdataServiceRest/ HTTP/1.1
 <h3 id="{{page.sections['interfaceInformation']['secs']['interfaceinformation'].anchor}}-objectstructure">Object Structure</h3>
 
 Interface information returns the highest available minor version of each major version. This lets the user decide which features can be used.
-As a minor version is backwards compatible to all previous minor versions, there is no point in enumerating them all. An user want to know which revision of each major version is available as that means they can work around possible bugs of older revisions.
+As a minor version is backwards compatible to all previous minor versions, there is no point in enumerating them all. A user wants to know which revision of each major version is available as that means they can work around possible bugs of older revisions.

--- a/_pages/API/v1.8/RawDataService/036-rawdataservice-events.md
+++ b/_pages/API/v1.8/RawDataService/036-rawdataservice-events.md
@@ -1,0 +1,25 @@
+<h2 id="{{page.sections['rawdataservice']['secs']['events'].anchor}}">{{page.sections['rawdataservice']['secs']['events'].title}}</h2>
+
+The PiWeb Server offers functionality for clients to be asynchronously notified of certain events, e.g. creation of raw data, using [SignalR](https://learn.microsoft.com/en-us/aspnet/core/signalr/introduction). A C# sample application using the PiWeb Server events endpoint can be found in the [PiWeb-Training Project](https://github.com/ZEISS-PiWeb/PiWeb-Training?tab=readme-ov-file#piwebapi---events) on GitHub.<br>
+Information and tutorials for different client technologies like .NET, JavaScript or Java can be found in the [SignalR client documentation](https://learn.microsoft.com/en-us/aspnet/core/signalr/client-features?view=aspnetcore-8.0).
+
+<h3 id="{{page.sections['rawdataservice']['secs']['events'].anchor}}-endpoints">Endpoint</h3>
+
+The events endpoint can be found under the route `http(s)://serverHost:port/events`. The endpoint is not part of the RawDataServiceRest, since it is able to send events for other parts of PiWeb, e.g. the [DataServiceRest](https://zeiss-piweb.github.io/PiWeb-Api/dataservice/v1.11/#ds-events "DataServiceRest events documentation").
+
+<h3 id="{{page.sections['interfaceInformation']['secs']['interfaceinformation'].anchor}}-objectstructure">Available Events</h3>
+
+The following listing contains all events available for the entities managed using the DataServiceRest as well as the provided information in the events.
+
+>{{ site.images['info'] }} You will only receive events for entities with corresponding permissions assigned to your user.
+
+#### Raw Data
+
+{% capture table %}
+Event Type      |  Property  |  Description
+----------------|-----------------------------------------------------------------------------------
+Created         | <code>int</code> Key <br> <code>string</code> TargetUuid <br><br><br> <nobr><code>string</code> RawDataEntity</nobr> <br> <code>string</code> Filename | The raw data key <br> The unique identifier of the inspection plan entity (part, characteristic, measurement, value) where the new raw data was added to. Remarks: Raw data of values use a compound UUID in the form of MeasurementUuid\|CharacteristicUuid. <br> The type of target entity (part, characteristic, measurement, value). <br> The file name of the raw data.
+Modified        | <code>int</code> Key <br> <code>string</code> TargetUuid <br><br><br> <code>string</code> RawDataEntity <br> <code>string</code> OldFilename <br> <code>string</code> NewFilename | The raw data key <br> The unique identifier of the inspection plan entity (part, characteristic, measurement, value) where the raw data was modified. Remarks: Raw data of values use a compound UUID in the form of MeasurementUuid\|CharacteristicUuid. <br> The type of target entity (part, characteristic, measurement, value). <br> The old file name of the raw data before modification. <br> The new file name of the raw data after modification.
+Deleted         | <code>int</code> Key <br> <code>string</code> TargetUuid <br><br><br> <code>string</code> RawDataEntity <br> <code>string</code> Filename | The raw data key <br> The unique identifier of the inspection plan entity (part, characteristic, measurement, value) where the new raw data was removed from. Remarks: Raw data of values use a compound UUID in the form of MeasurementUuid\|CharacteristicUuid. <br> The type of target entity (part, characteristic, measurement, value). <br> The file name of the deleted data.
+{% endcapture %}
+{{ table | markdownify | replace: '<table>', '<table class="table table-inline">' }}

--- a/_pages/SDK/v8.3/02-netsdk.md
+++ b/_pages/SDK/v8.3/02-netsdk.md
@@ -4,7 +4,7 @@ title: .NET SDK
 level: 0
 version: 83
 displayVersion: "8.3"
-isCurrentVersion: true
+isCurrentVersion: false
 permalink: "/sdk/v8.3/"
 sections:
   general:

--- a/_pages/SDK/v9.0/02-netsdk.md
+++ b/_pages/SDK/v9.0/02-netsdk.md
@@ -4,7 +4,7 @@ title: .NET SDK
 level: 0
 version: 90
 displayVersion: "9.0"
-isCurrentVersion: false
+isCurrentVersion: true
 permalink: "/sdk/v9.0/"
 sections:
   general:
@@ -37,7 +37,7 @@ sections:
     anchor: migration
     secs:
       nuget:
-        title: NuGet Version 6.0.0
+        title: NuGet Version 8.0.0
         anchor: mig-nuget
       structure:
         title: New structure


### PR DESCRIPTION
This PR updates the documentation to the most recent version of the PiWeb API and its NuGet.

Changes:
1st commit: Update current versions
- update current versions of pages

2nd commit: Add new feature documentation
- add count endpoints for parts and characteristics
- add events to DataServiceRest page
- add events to RawDataServiceRest page
- update release notes

3rd commit: Fix small issues
- add information for history comment on inspection plan updates
- fix wrong max value for depth
- fix typos