### PR TITLE
doc: Remove WIP message from SDK doc

### DIFF
--- a/_pages/SDK/v9.0/02-netsdk.md
+++ b/_pages/SDK/v9.0/02-netsdk.md
@@ -49,11 +49,6 @@ sections:
 
 ---
 
-<div class="alert alert-info fade in">
-  <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-  This page is still a work in progress! It is possible that not all information are up to date!
-</div>
-
 {% include version_combobox.html %}
 
 {% include_relative 021-general.md %}


### PR DESCRIPTION
Remove WIP message from SDK documentation, since it is no longer needed.