### PR TITLE
Fix: automatically choose access token type

### DIFF
--- a/src/Api.Rest/Common/Utilities/OAuthHelper.cs
+++ b/src/Api.Rest/Common/Utilities/OAuthHelper.cs
@@ -75,6 +75,33 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Utilities
 		}
 
 		/// <summary>
+		/// Extract the value of the JWT 'exp' token claim and convert it to the expiration date.
+		/// </summary>
+		/// <param name="jwtEncodedString">The JWT encoded token string.</param>
+		/// <returns>The expiration date of the token in UTC time.</returns>
+		public static DateTime TokenToExpirationTime( string jwtEncodedString )
+		{
+			if( string.IsNullOrEmpty( jwtEncodedString ) )
+				return default;
+
+			try
+			{
+				var claims = GetClaimsFromSecurityToken( jwtEncodedString ).ToList();
+				var expClaim = claims.SingleOrDefault( claim => claim.Type == "exp" )?.Value;
+
+				return long.TryParse( expClaim, out var secondsSinceEpoch )
+					? DateTimeOffset.FromUnixTimeSeconds( secondsSinceEpoch ).UtcDateTime
+					: default;
+			}
+			catch
+			{
+				// ignored
+			}
+
+			return default;
+		}
+
+		/// <summary>
 		/// Extract the value of the email identity claim.
 		/// </summary>
 		/// <param name="claims">A collection of claims.</param>
@@ -318,6 +345,5 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Utilities
 		}
 
 		#endregion
-
 	}
 }

--- a/src/Api.Rest/HttpClient/OAuth/AccessTokenType.cs
+++ b/src/Api.Rest/HttpClient/OAuth/AccessTokenType.cs
@@ -1,0 +1,34 @@
+﻿#region copyright
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Carl Zeiss Industrielle Messtechnik GmbH        */
+/* Softwaresystem PiWeb                            */
+/* (c) Carl Zeiss 2024                             */
+/* * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#endregion
+
+namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth;
+
+/// <summary>
+/// Enum representing the different modes to select the token type which can be used as an PiWeb access token.
+/// </summary>
+public enum AccessTokenType
+{
+	/// <summary>
+	/// The clients automatically chooses a matching token in JWT format based on the following criteria:
+	/// If the OAuth Access Token is a JWT, use this.
+	/// If not, use the ID Token (JWT per OIDC definition).
+	/// </summary>
+	Auto,
+
+	/// <summary>
+	/// Force the client to use the ID Token.
+	/// </summary>
+	OidcIdentityToken,
+
+	/// <summary>
+	/// Force the client to use the OAuth Access Token.
+	/// </summary>
+	OAuthAccessToken
+}

--- a/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/AuthorizationCodeFlow.cs
+++ b/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/AuthorizationCodeFlow.cs
@@ -83,8 +83,7 @@ public class AuthorizationCodeFlow : OidcAuthenticationFlowBase, IOidcAuthentica
 	public OAuthTokenCredential ExecuteAuthenticationFlow( string refreshToken, OAuthConfiguration configuration, Func<OAuthRequest, OAuthResponse> requestCallback )
 	{
 		var discoveryInfo = GetDiscoveryInfoAsync( configuration.UpstreamTokenInformation ).GetAwaiter().GetResult();
-		if( discoveryInfo.IsError )
-			return null;
+		ThrowOnInvalidDiscoveryDocument( discoveryInfo );
 
 		var tokenClient = CreateTokenClient( discoveryInfo.TokenEndpoint, configuration.UpstreamTokenInformation.ClientID );
 		var result = TryGetOAuthTokenFromRefreshTokenAsync( tokenClient, discoveryInfo.UserInfoEndpoint, refreshToken, configuration ).GetAwaiter().GetResult();
@@ -101,8 +100,7 @@ public class AuthorizationCodeFlow : OidcAuthenticationFlowBase, IOidcAuthentica
 		var request = new OAuthRequest( startUrl, configuration.UpstreamTokenInformation.RedirectUri );
 		var response = requestCallback( request )?.ToAuthorizeResponse();
 
-		if( response == null )
-			return null;
+		ThrowOnInvalidAuthorizeResponse( response );
 
 		result = TryGetOAuthTokenFromAuthorizeResponseAsync( tokenClient, cryptoNumbers, response, configuration, discoveryInfo ).GetAwaiter().GetResult();
 
@@ -113,8 +111,7 @@ public class AuthorizationCodeFlow : OidcAuthenticationFlowBase, IOidcAuthentica
 	public async Task<OAuthTokenCredential> ExecuteAuthenticationFlowAsync( string refreshToken, OAuthConfiguration configuration, Func<OAuthRequest, Task<OAuthResponse>> requestCallbackAsync )
 	{
 		var discoveryInfo = await GetDiscoveryInfoAsync( configuration.UpstreamTokenInformation ).ConfigureAwait( false );
-		if( discoveryInfo.IsError )
-			return null;
+		ThrowOnInvalidDiscoveryDocument( discoveryInfo );
 
 		var tokenClient = CreateTokenClient( discoveryInfo.TokenEndpoint, configuration.UpstreamTokenInformation.ClientID );
 		var result = await TryGetOAuthTokenFromRefreshTokenAsync( tokenClient, discoveryInfo.UserInfoEndpoint, refreshToken, configuration ).ConfigureAwait( false );
@@ -131,8 +128,7 @@ public class AuthorizationCodeFlow : OidcAuthenticationFlowBase, IOidcAuthentica
 		var request = new OAuthRequest( startUrl, configuration.UpstreamTokenInformation.RedirectUri );
 		var response = ( await requestCallbackAsync( request ).ConfigureAwait( false ) )?.ToAuthorizeResponse();
 
-		if( response == null )
-			return null;
+		ThrowOnInvalidAuthorizeResponse( response );
 
 		result = await TryGetOAuthTokenFromAuthorizeResponseAsync( tokenClient, cryptoNumbers, response, configuration, discoveryInfo ).ConfigureAwait( false );
 

--- a/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/HybridFlow.cs
+++ b/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/HybridFlow.cs
@@ -32,11 +32,13 @@ public class HybridFlow : OidcAuthenticationFlowBase, IOidcAuthenticationFlow
 		TokenClient tokenClient,
 		CryptoNumbers cryptoNumbers,
 		AuthorizeResponse response,
-		OAuthTokenInformation tokenInformation,
+		OAuthConfiguration configuration,
 		DiscoveryDocumentResponse discoveryDocument )
 	{
 		if( response == null )
 			return null;
+
+		var tokenInformation = configuration.LocalTokenInformation;
 
 		// decode the IdentityToken claims
 		var decodedToken = OAuthHelper.DecodeSecurityToken( response.IdentityToken );
@@ -72,7 +74,13 @@ public class HybridFlow : OidcAuthenticationFlowBase, IOidcAuthenticationFlow
 		if( tokenResponse.IsError )
 			throw new InvalidOperationException( $"Error during request of access token using authorization code: {tokenResponse.Error}." );
 
-		return OAuthTokenCredential.CreateWithIdentityToken( tokenResponse.IdentityToken, tokenResponse.AccessToken, DateTime.UtcNow + TimeSpan.FromSeconds( tokenResponse.ExpiresIn ), tokenResponse.RefreshToken );
+		var accessToken = ChooseAccessToken( tokenResponse, configuration, out var expirationDate );
+
+		return OAuthTokenCredential.CreateWithIdentityToken(
+			tokenResponse.IdentityToken,
+			accessToken,
+			expirationDate,
+			tokenResponse.RefreshToken );
 	}
 
 	#endregion
@@ -87,7 +95,7 @@ public class HybridFlow : OidcAuthenticationFlowBase, IOidcAuthenticationFlow
 			return null;
 
 		var tokenClient = CreateTokenClient( discoveryInfo.TokenEndpoint, configuration.LocalTokenInformation.ClientID );
-		var result = TryGetOAuthTokenFromRefreshTokenAsync( tokenClient, discoveryInfo.UserInfoEndpoint, refreshToken ).GetAwaiter().GetResult();
+		var result = TryGetOAuthTokenFromRefreshTokenAsync( tokenClient, discoveryInfo.UserInfoEndpoint, refreshToken, configuration ).GetAwaiter().GetResult();
 		if( result != null )
 			return result;
 
@@ -104,7 +112,7 @@ public class HybridFlow : OidcAuthenticationFlowBase, IOidcAuthenticationFlow
 		if( response == null )
 			return null;
 
-		result = TryGetOAuthTokenFromAuthorizeResponseAsync( tokenClient, cryptoNumbers, response, configuration.LocalTokenInformation, discoveryInfo ).GetAwaiter().GetResult();
+		result = TryGetOAuthTokenFromAuthorizeResponseAsync( tokenClient, cryptoNumbers, response, configuration, discoveryInfo ).GetAwaiter().GetResult();
 
 		return result;
 	}
@@ -117,7 +125,7 @@ public class HybridFlow : OidcAuthenticationFlowBase, IOidcAuthenticationFlow
 			return null;
 
 		var tokenClient = CreateTokenClient( discoveryInfo.TokenEndpoint, configuration.LocalTokenInformation.ClientID );
-		var result = await TryGetOAuthTokenFromRefreshTokenAsync( tokenClient, discoveryInfo.UserInfoEndpoint, refreshToken ).ConfigureAwait( false );
+		var result = await TryGetOAuthTokenFromRefreshTokenAsync( tokenClient, discoveryInfo.UserInfoEndpoint, refreshToken, configuration ).ConfigureAwait( false );
 		if( result != null )
 			return result;
 
@@ -134,7 +142,7 @@ public class HybridFlow : OidcAuthenticationFlowBase, IOidcAuthenticationFlow
 		if( response == null )
 			return null;
 
-		result = await TryGetOAuthTokenFromAuthorizeResponseAsync( tokenClient, cryptoNumbers, response, configuration.LocalTokenInformation, discoveryInfo ).ConfigureAwait( false );
+		result = await TryGetOAuthTokenFromAuthorizeResponseAsync( tokenClient, cryptoNumbers, response, configuration, discoveryInfo ).ConfigureAwait( false );
 
 		return result;
 	}

--- a/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/HybridFlow.cs
+++ b/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/HybridFlow.cs
@@ -91,8 +91,7 @@ public class HybridFlow : OidcAuthenticationFlowBase, IOidcAuthenticationFlow
 	public OAuthTokenCredential ExecuteAuthenticationFlow( string refreshToken, OAuthConfiguration configuration, Func<OAuthRequest, OAuthResponse> requestCallback )
 	{
 		var discoveryInfo = GetDiscoveryInfoAsync( configuration.LocalTokenInformation ).GetAwaiter().GetResult();
-		if( discoveryInfo.IsError )
-			return null;
+		ThrowOnInvalidDiscoveryDocument( discoveryInfo );
 
 		var tokenClient = CreateTokenClient( discoveryInfo.TokenEndpoint, configuration.LocalTokenInformation.ClientID );
 		var result = TryGetOAuthTokenFromRefreshTokenAsync( tokenClient, discoveryInfo.UserInfoEndpoint, refreshToken, configuration ).GetAwaiter().GetResult();
@@ -109,8 +108,7 @@ public class HybridFlow : OidcAuthenticationFlowBase, IOidcAuthenticationFlow
 		var request = new OAuthRequest( startUrl, configuration.LocalTokenInformation.RedirectUri );
 		var response = requestCallback( request )?.ToAuthorizeResponse();
 
-		if( response == null )
-			return null;
+		ThrowOnInvalidAuthorizeResponse( response );
 
 		result = TryGetOAuthTokenFromAuthorizeResponseAsync( tokenClient, cryptoNumbers, response, configuration, discoveryInfo ).GetAwaiter().GetResult();
 
@@ -121,8 +119,7 @@ public class HybridFlow : OidcAuthenticationFlowBase, IOidcAuthenticationFlow
 	public async Task<OAuthTokenCredential> ExecuteAuthenticationFlowAsync( string refreshToken, OAuthConfiguration configuration, Func<OAuthRequest, Task<OAuthResponse>> requestCallbackAsync )
 	{
 		var discoveryInfo = await GetDiscoveryInfoAsync( configuration.LocalTokenInformation ).ConfigureAwait( false );
-		if( discoveryInfo.IsError )
-			return null;
+		ThrowOnInvalidDiscoveryDocument( discoveryInfo );
 
 		var tokenClient = CreateTokenClient( discoveryInfo.TokenEndpoint, configuration.LocalTokenInformation.ClientID );
 		var result = await TryGetOAuthTokenFromRefreshTokenAsync( tokenClient, discoveryInfo.UserInfoEndpoint, refreshToken, configuration ).ConfigureAwait( false );
@@ -139,8 +136,7 @@ public class HybridFlow : OidcAuthenticationFlowBase, IOidcAuthenticationFlow
 		var request = new OAuthRequest( startUrl, configuration.LocalTokenInformation.RedirectUri );
 		var response = ( await requestCallbackAsync( request ).ConfigureAwait( false ) )?.ToAuthorizeResponse();
 
-		if( response == null )
-			return null;
+		ThrowOnInvalidAuthorizeResponse( response );
 
 		result = await TryGetOAuthTokenFromAuthorizeResponseAsync( tokenClient, cryptoNumbers, response, configuration, discoveryInfo ).ConfigureAwait( false );
 

--- a/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/OidcAuthenticationFlowBase.cs
+++ b/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/OidcAuthenticationFlowBase.cs
@@ -146,6 +146,34 @@ public abstract class OidcAuthenticationFlowBase
 			tokenResponse.RefreshToken );
 	}
 
+	/// <summary>
+	/// Check authorization response and throw if it is invalid.
+	/// </summary>
+	/// <param name="response">The received authorization response.</param>
+	/// <exception cref="InvalidOperationException">Authorization response is empty or has an error.</exception>
+	protected static void ThrowOnInvalidAuthorizeResponse( AuthorizeResponse response )
+	{
+		if( response == null )
+			throw new InvalidOperationException( "Error during request of access token using authorization code: authorization response was empty." );
+
+		if( response.IsError )
+			throw new InvalidOperationException( $"Error during request of access token using authorization code: {response.Error}. {response.ErrorDescription}." );
+	}
+
+	/// <summary>
+	/// Checks discovery response and throws if it is invalid.
+	/// </summary>
+	/// <param name="response">The received discovery response.</param>
+	/// <exception cref="InvalidOperationException">Discovery response is empty or has an error.</exception>
+	protected static void ThrowOnInvalidDiscoveryDocument( DiscoveryDocumentResponse response )
+	{
+		if( response == null )
+			throw new InvalidOperationException( "Error during request of discovery document: discovery response was empty." );
+
+		if( response.IsError )
+			throw new InvalidOperationException( $"Error during request of discovery document: {response.Error}." );
+	}
+
 	private static async Task<OAuthTokenCredential> CreateCredentialsWithClaimsFromUserInfo( string userInfoEndpoint, TokenResponse tokenResponse, OAuthConfiguration configuration )
 	{
 		var accessToken = ChooseAccessToken( tokenResponse, configuration, out var expirationDate );

--- a/src/Api.Rest/HttpClient/OAuth/OAuthConfiguration.cs
+++ b/src/Api.Rest/HttpClient/OAuth/OAuthConfiguration.cs
@@ -14,7 +14,6 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth;
 #region usings
 
 using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using Newtonsoft.Json;
 
 #endregion
@@ -25,6 +24,13 @@ using Newtonsoft.Json;
 public class OAuthConfiguration
 {
 	#region properties
+
+	/// <summary>
+	/// Mode to select the token type which can be used as an access token.
+	/// </summary>
+	[JsonProperty( "accessTokenType" )]
+	[JsonPropertyName( "accessTokenType" )]
+	public AccessTokenType AccessTokenType { get; set; } = AccessTokenType.Auto;
 
 	/// <summary>
 	/// Flags enum representing the OIDC authentication flows supported by this PiWeb Server.


### PR DESCRIPTION
Commit 1 - fix: Automatically choose suitable JWT token as AccessToken
- use ID token as fallback if AccessToken is no JWT
- allow configuration from the server to enforce certain token type
- select the expiration time from the chosen token, in case times differ between ID and AccessToken

Commit 2 - fix: Throw error on problems during OIDC login
- do not silently accept error states of the authentication procedure but throw an exception instead
- this way the user can better understand why the login failed (e.g. invalid configuration for OIDC)
- only throw during manual login, but not on refresh (to allow for simply logging in again if refresh fails, an exception would not bring up the login dialog)