### PR TITLE
Fix: Token expiration time extraction

### DIFF
--- a/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/OidcAuthenticationFlowBase.cs
+++ b/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/OidcAuthenticationFlowBase.cs
@@ -54,10 +54,16 @@ public abstract class OidcAuthenticationFlowBase
 					return tokenResponse.IdentityToken;
 				}
 			case AccessTokenType.OidcIdentityToken:
+			{
+				expiration = OAuthHelper.TokenToExpirationTime( tokenResponse.IdentityToken );
 				return tokenResponse.IdentityToken;
+			}
 			case AccessTokenType.OAuthAccessToken:
 			default:
+			{
+				expiration = DateTime.UtcNow + TimeSpan.FromSeconds( tokenResponse.ExpiresIn );
 				return tokenResponse.AccessToken;
+			}
 		}
 	}
 


### PR DESCRIPTION
- expiration time was not extracted for token selection modes other than auto, meaning all token would be expired due to DateTime default
- for OIDC ID Token we extract it from the token itself (as done in the auto case)
- for OAuth Access Token we use the expiration from the token request (as done in the auto case)