### PR TITLE
[PIWEB-21318] Improve access token caching

### DIFF
--- a/src/Api.Rest/Common/Utilities/OAuthHelper.cs
+++ b/src/Api.Rest/Common/Utilities/OAuthHelper.cs
@@ -280,8 +280,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Utilities
 			if( result == null )
 				return null;
 
-			if( !bypassLocalCache )
-				AccessTokenCache.Store( instanceUrl, result );
+			AccessTokenCache.Store( instanceUrl, result );
 
 			return result;
 		}
@@ -317,8 +316,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Utilities
 			if( result == null )
 				return null;
 
-			if( !bypassLocalCache )
-				AccessTokenCache.Store( instanceUrl, result );
+			AccessTokenCache.Store( instanceUrl, result );
 
 			return result;
 		}

--- a/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/IOidcAuthenticationFlow.cs
+++ b/src/Api.Rest/HttpClient/OAuth/AuthenticationFlows/IOidcAuthenticationFlow.cs
@@ -13,6 +13,7 @@ namespace Zeiss.PiWeb.Api.Rest.HttpClient.OAuth.AuthenticationFlows;
 #region usings
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Zeiss.PiWeb.Api.Rest.Common.Utilities;
@@ -42,9 +43,11 @@ public interface IOidcAuthenticationFlow
 	/// <param name="refreshToken">Refresh token to acquire a new authentication token.</param>
 	/// <param name="configuration">OAuth configuration containing the settings for authentication.</param>
 	/// <param name="requestCallbackAsync">The asynchronous callback to execute for authentication, e.g opening a browser window.</param>
+	/// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the operation.</param>
 	Task<OAuthTokenCredential> ExecuteAuthenticationFlowAsync( [CanBeNull] string refreshToken,
 		OAuthConfiguration configuration,
-		Func<OAuthRequest, Task<OAuthResponse>> requestCallbackAsync );
+		Func<OAuthRequest, Task<OAuthResponse>> requestCallbackAsync,
+		CancellationToken cancellationToken );
 
 	#endregion
 }


### PR DESCRIPTION
[PIWEB-21318] fix: Always store valid access tokens in local cache

* If we obtain a valid access token, we should always store that in the local cache, no matter what
* When we don't store that we can never explicitly trigger the creation of a new token from calling code that is reused (stored in cache)
* We either trigger the creation of a token that is not stored or we get a possibly outdated token from cache - neither of these 2 conditions is great