### PR TITLE
Public RestClient Constructor

### DIFF
--- a/src/Api.Rest/Common/Client/RestClient.cs
+++ b/src/Api.Rest/Common/Client/RestClient.cs
@@ -39,7 +39,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 		/// </summary>
 		/// <exception cref="ArgumentNullException"><paramref name="endpointName"/> is <see langword="null" />.</exception>
 		/// <exception cref="ArgumentNullException"><paramref name="settings"/> is <see langword="null" />.</exception>
-		internal RestClient( [NotNull] string endpointName, [NotNull] RestClientSettings settings )
+		public RestClient( [NotNull] string endpointName, [NotNull] RestClientSettings settings )
 			: base( endpointName, settings )
 		{ }
 

--- a/src/Api.Rest/Common/Client/RestClientBase.cs
+++ b/src/Api.Rest/Common/Client/RestClientBase.cs
@@ -155,7 +155,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 		/// Initializes a new instance of the <see cref="RestClientBase"/> class. This constructor exists to support
 		/// rest client creation via <see cref="RestClientBuilder"/>.
 		/// </summary>
-		internal RestClientBase( [NotNull] string endpointName, [NotNull] RestClientSettings settings )
+		protected RestClientBase( [NotNull] string endpointName, [NotNull] RestClientSettings settings )
 		{
 			if( endpointName == null )
 				throw new ArgumentNullException( nameof( endpointName ) );

--- a/src/Api.Rest/Common/Client/RestClientBase.cs
+++ b/src/Api.Rest/Common/Client/RestClientBase.cs
@@ -95,7 +95,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 		private long _LatestSession = 0;
 
 		// This is only used by the legacy constructor to preserve old behavior
-		[CanBeNull] private readonly DelegatingHandler _CustomHttpMessageHandler;
+		[CanBeNull] private readonly DelegatingHandler _LegacyDelegatingHandler;
 
 		// These are set by the settings based constructor used by rest client builders
 		[NotNull] private readonly IReadOnlyCollection<Func<DelegatingHandler>> _DelegatingHandlerFactories =
@@ -142,7 +142,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 			}.Uri;
 
 			_Chunked = chunked;
-			_CustomHttpMessageHandler = customHttpMessageHandler;
+			_LegacyDelegatingHandler = customHttpMessageHandler;
 			_Serializer = serializer ?? ObjectSerializer.Default;
 
 			MaxUriLength = maxUriLength;
@@ -172,7 +172,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 			_CheckCertificateRevocationList = settings.CheckCertificateRevocationList;
 			_Chunked = settings.AllowChunkedDataTransfer;
 
-			_CustomHttpMessageHandler = null;
+			_LegacyDelegatingHandler = null;
 			_AuthenticationHandler = settings.AuthenticationHandler;
 
 			_DelegatingHandlerFactories = new List<Func<DelegatingHandler>>( settings.DelegatingHandlerFactories );
@@ -202,7 +202,7 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 		/// </summary>
 		public TimeSpan Timeout
 		{
-			get => _TimeoutHandler.Timeout;
+			get => _Timeout;
 			set
 			{
 				_Timeout = Timeout;
@@ -705,41 +705,46 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 #pragma warning restore CA1416
 			}
 
+			HttpMessageHandler outerDelegatingHandler = _HttpClientHandler;
+
 			if( _CacheStore == null )
+			{
 				_CachingHandler = null;
+			}
 			else
 			{
 				_CachingHandler = _VaryHeaderStore == null
 					? new CachingHandler( _CacheStore )
 					: new CachingHandler( _CacheStore, _VaryHeaderStore );
-
-				_CachingHandler.InnerHandler = _HttpClientHandler;
 				_CachingHandler.DoNotEmitCacheCowHeader = true;
+
+				_CachingHandler.InnerHandler = outerDelegatingHandler;
+				outerDelegatingHandler = _CachingHandler;
 			}
 
 			_TimeoutHandler = new TimeoutHandler
 			{
 				Timeout = _Timeout,
-				InnerHandler = (HttpMessageHandler)_CachingHandler ?? _HttpClientHandler
+				InnerHandler = outerDelegatingHandler
 			};
+			outerDelegatingHandler = _TimeoutHandler;
 
-			var outerMostHandler = (DelegatingHandler)_TimeoutHandler;
 			foreach( var handlerFactory in _DelegatingHandlerFactories )
 			{
 				var newHandler = handlerFactory();
 				_DelegatingHandlers.Add( newHandler );
 
-				newHandler.InnerHandler = outerMostHandler;
-				outerMostHandler = newHandler;
+				newHandler.InnerHandler = outerDelegatingHandler;
+				outerDelegatingHandler = newHandler;
 			}
 
-			if( _CustomHttpMessageHandler != null )
+			if( _LegacyDelegatingHandler != null )
 			{
-				_CustomHttpMessageHandler.InnerHandler = outerMostHandler;
-				outerMostHandler = _CustomHttpMessageHandler;
+				_LegacyDelegatingHandler.InnerHandler = outerDelegatingHandler;
+				outerDelegatingHandler = _LegacyDelegatingHandler;
 			}
 
-			_HttpClient = new HttpClient( outerMostHandler )
+			_HttpClient = new HttpClient( outerDelegatingHandler )
 			{
 				Timeout = System.Threading.Timeout.InfiniteTimeSpan,
 				BaseAddress = ServiceLocation

--- a/src/Api.Rest/Common/Client/TimeoutHandler.cs
+++ b/src/Api.Rest/Common/Client/TimeoutHandler.cs
@@ -50,16 +50,16 @@ namespace Zeiss.PiWeb.Api.Rest.Common.Client
 		{
 			using( var cts = GetCancellationTokenSource( cancellationToken ) )
 			{
-				var timeoutTime = cts is null
-					? 0
-					: Environment.TickCount + Timeout.Ticks / TimeSpan.TicksPerMillisecond;
+				var timeoutTickCount = cts is null
+					? long.MaxValue
+					: Environment.TickCount + Timeout.Ticks;
 
 				try
 				{
 					return await base.SendAsync( request, cts?.Token ?? cancellationToken )
 						.ConfigureAwait( false );
 				}
-				catch( OperationCanceledException ex ) when( !cancellationToken.IsCancellationRequested && Environment.TickCount >= timeoutTime )
+				catch( OperationCanceledException ex ) when( !cancellationToken.IsCancellationRequested && Environment.TickCount >= timeoutTickCount )
 				{
 					throw new TimeoutException(
 						$"The request was canceled due to the configured timeout of {Timeout.TotalSeconds} seconds elapsing.", ex );

--- a/src/Api.Rest/HttpClient/Builder/RestClientBuilder.cs
+++ b/src/Api.Rest/HttpClient/Builder/RestClientBuilder.cs
@@ -365,8 +365,7 @@ public class RestClientBuilder : IRestClientBuilder, IDisposable
 	/// <inheritdoc />
 	public DataServiceRestClient CreateDataServiceRestClient()
 	{
-		var settings = GetSettings();
-		return new DataServiceRestClient( settings );
+		return new DataServiceRestClient( GetSettings() );
 	}
 
 	/// <inheritdoc />


### PR DESCRIPTION
Makes the RestClient constructor taking a settings object public so that custom rest clients based on RestClient can be implemented by API users.