### PR TITLE
doc: Add RestClientBuilder and filename encoding to documentation

### DIFF
--- a/_pages/API/v1.8/RawDataService/034-rawdataservice-rawdataobjects.md
+++ b/_pages/API/v1.8/RawDataService/034-rawdataservice-rawdataobjects.md
@@ -102,7 +102,7 @@ Content-MD5          | (*optional*) Includes file's MD5 hash sum in Base64 forma
 {% endcapture %}
 {{ table | markdownify | replace: '<table>', '<table class="table table-hover">' }}
 
->{{site.images['info']}} The allowed raw data file names (see `Content-Disposition`) can be restricted on the server.
+>{{site.images['info']}} The allowed raw data file names (see `Content-Disposition`) can be restricted. See the option `Restrict filenames by a whitelist` in the advanced options of the PiWeb Server.
 
 >{{site.images['info']}} When adding a file, you can pass the desired file key as part of the uri. If you pass -1 or no key, the next available key will automatically be assigned by the server (recommended) and can be read from the result.
 
@@ -245,3 +245,12 @@ HTTP/1.1 200 OK
 {% endcapture %}
 
 {% include endpointTab.html %}
+
+<h4>Encoding filenames</h4>
+
+Per definition, HTTP headers are ASCII-only, making special characters in the filename sent via Content-Disposition header slightly more complex. When using our .NET SDK NuGet, the framework does all encoding when it encounters non-ASCII-characters. For this, it is using the [Encoded-Word](https://en.wikipedia.org/wiki/MIME#Encoded-Word) syntax. An example header value would look like this:
+
+`attachment; filename="=?utf-8?B?ZsO2w7Ziw6RyLnR4dA==?="`
+
+Where `utf-8` ist the charset, `B` is the encoding (Base64), and the following `ZsO2w7Ziw6RyLnR4dA==` is the actual filename in Base64 encoding, e.g. `fööbär.txt` in this example. All separated by `?`, 
+with a leading `=?` and trailing `?=`. Other charsets and encodings are possible, you can find more information about this in the documentation of used Encoded-Word syntax. When using the RawDataService directly via REST, you may need to implement this yourself.

--- a/_pages/SDK/v9.1/022-basics/0220-basics-create.md
+++ b/_pages/SDK/v9.1/022-basics/0220-basics-create.md
@@ -6,7 +6,7 @@ Examples in this section:
 + [Creating REST clients using the RestClientBuilder](#-example--creating-rest-clients-using-the-restclientbuilder)
 <hr>
 
-Creating a .NET REST client is quite simple. You choose the required client based on the use case (DataService for parts, measurements, values and configuration, or RawDataService for additional data), and pass in the `Uri` object pointing to your PiWeb server or your PiWeb cloud database. The SDK also offers a RestClientBuilder for easy creation and configuration of necessary REST clients with a fluent syntax. 
+Creating a .NET REST client is quite simple. You choose the required client based on the use case (`DataServiceRestClient` for parts, measurements, values and configuration, or `RawDataServiceRestClient` for additional data), and pass in the `Uri` object pointing to your PiWeb server or your PiWeb cloud database. The SDK also offers a `RestClientBuilder` for easy creation and configuration of necessary REST clients with a fluent syntax. 
 
 The `Uri` for your PiWeb server can be found in the PiWeb server UI. The `Uri` for PiWeb cloud is the base URI https://piwebcloud-service.metrology.zeiss.com with the database id appended. The database id can be found
 in PiWeb cloud portal.

--- a/_pages/SDK/v9.1/022-basics/0220-basics-create.md
+++ b/_pages/SDK/v9.1/022-basics/0220-basics-create.md
@@ -3,12 +3,15 @@
 Examples in this section:
 + [Creating a DataServiceClient](#-example--creating-a-dataserviceclient)
 + [Creating a RawDataServiceClient](#-example--creating-a-rawdataserviceclient)
++ [Creating REST clients using the RestClientBuilder](#-example--creating-rest-clients-using-the-restclientbuilder)
 <hr>
 
-Creating a .NET REST client is quite simple. You choose the required client based on the use case (DataService for parts, measurements, values and configuration, or RawDataService for additional data), and pass in the `Uri` object pointing to your PiWeb server or your PiWeb cloud database.
+Creating a .NET REST client is quite simple. You choose the required client based on the use case (DataService for parts, measurements, values and configuration, or RawDataService for additional data), and pass in the `Uri` object pointing to your PiWeb server or your PiWeb cloud database. The SDK also offers a RestClientBuilder for easy creation and configuration of necessary REST clients with a fluent syntax. 
 
 The `Uri` for your PiWeb server can be found in the PiWeb server UI. The `Uri` for PiWeb cloud is the base URI https://piwebcloud-service.metrology.zeiss.com with the database id appended. The database id can be found
 in PiWeb cloud portal.
+
+>{{ site.images['info'] }} All REST clients implement the `IDisposable` interface, keep in mind to dispose the client during shutdown of your application.
 
 {{ site.headers['example'] }} Creating a DataServiceClient
 
@@ -17,7 +20,7 @@ in PiWeb cloud portal.
 var uri = new Uri( "http://piwebserver:8080" );
 
 //Creating the client
-var DataServiceClient = new DataServiceRestClient( uri );
+using var DataServiceClient = new DataServiceRestClient( uri );
 {% endhighlight %}
 <br>
 {{ site.headers['example'] }} Creating a RawDataServiceClient
@@ -27,9 +30,33 @@ var DataServiceClient = new DataServiceRestClient( uri );
 var uri = new Uri( "https://piwebcloud-service.metrology.zeiss.com/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" );
 
 //Creating the client
-var RawDataServiceClient = new RawDataServiceRestClient( uri );
+using var RawDataServiceClient = new RawDataServiceRestClient( uri );
 {% endhighlight %}
 <br>
 >{{ site.images['info'] }} Each method runs asynchronously and returns an awaitable `Task`. The result will be available once the `Task` has completed.
 
 >{{ site.images['info'] }} All methods accept a `CancellationToken` which you can use to cancel a request.
+<br>
+<h4>Using the RestClientBuilder</h4>
+Our .NET SDK offers a `RestClientBuilder` for easy creation and configuration of necessary REST clients with a fluent syntax. You configure this builder once, and can then create identically configured REST clients.
+While REST clients should be reused and have a longer lifespan, using the builder is a convenient way of efficiently creating REST clients where reusing them is not feasable. A number of settings can optionally be configured before actually creating the REST clients. Default values are assumed for any setting that is not configured. The only required setting is the PiWeb Server uri which has no sensible default value. For all available settings, check the offered methods of the `RestClientBuilder` in your IDE.
+
+{{ site.headers['example'] }} Creating REST clients using the RestClientBuilder
+
+{% highlight csharp %}
+//The Uri of your PiWeb server or PiWeb cloud database
+var uri = new Uri( "http://piwebserver:8080" );
+
+//Creating the builder
+using var restClientBuilder = new RestClientBuilder( uri );
+
+//Configure the builder
+restClientBuilder
+    .SetTimeout( TimeSpan.FromMinutes( 5 ) )
+    .SetMaxUriLength( 8192 )
+    .SetMaxRequestsInParallel( 8 );
+
+//Create the REST clients using the builder
+using var DataServiceClient = restClientBuilder.CreateDataServiceRestClient();
+using var RawDataServiceClient = restClientBuilder.CreateRawDataServiceRestClient();    
+{% endhighlight %}


### PR DESCRIPTION
- add new way of creating the RestClients using the RestClientBuilder
- add using statement and hint that the RestClients implement IDisposable
- describe how to use encoded-word syntax for sending non-ASCII characters in the Content-Disposition header