### PR TITLE
fix: Add null check for RequestUri

### DIFF
--- a/src/Api.Rest.Tests/Common/Client/HttpClientRestClientTests.cs
+++ b/src/Api.Rest.Tests/Common/Client/HttpClientRestClientTests.cs
@@ -125,6 +125,23 @@ public sealed class HttpClientRestClientTests
 	}
 
 	[Test]
+	public async Task RequestEndpointName_ResponseIsSuccessful_ReturnsDeserializedObject()
+	{
+		using var server = WebServer.StartNew( Port );
+		using var httpClient = new HttpClient { BaseAddress = Uri };
+		var client = new HttpClientRestClient( httpClient, endpointName: "api/" );
+		var expected = new Error( "from api endpoint" );
+		server.RegisterResponse( "/api/", JsonConvert.SerializeObject( expected ) );
+
+		var result = await client.Request<Error>(
+			() => new HttpRequestMessage( HttpMethod.Get, "" ),
+			CancellationToken.None );
+
+		result.Should().BeEquivalentTo( expected );
+		server.ReceivedRequests.Should().ContainSingle().Which.Should().Be( $"{Uri}api/" );
+	}
+
+	[Test]
 	public async Task Request_ResponseIsClientError_ThrowsWrappedServerErrorException()
 	{
 		using var server = WebServer.StartNew( Port );

--- a/src/Api.Rest/Common/Client/HttpClientRestClient.cs
+++ b/src/Api.Rest/Common/Client/HttpClientRestClient.cs
@@ -80,7 +80,7 @@ public sealed class HttpClientRestClient : RestClientBase
 			SetDefaultHttpHeaders( request );
 
 			if( !string.IsNullOrWhiteSpace( _EndpointName ) )
-				request.RequestUri = new Uri( _EndpointName.TrimEnd( '/' ) + "/" + request.RequestUri.OriginalString.TrimStart( '/' ), UriKind.Relative );
+				request.RequestUri = new Uri( _EndpointName.TrimEnd( '/' ) + "/" + request.RequestUri?.OriginalString?.TrimStart( '/' ), UriKind.Relative );
 
 			response = await _HttpClient.SendAsync( request, completionOptions, cancellationToken ).ConfigureAwait( false );
 


### PR DESCRIPTION
Updated RequestUri usage with null-conditional operators to prevent NullReferenceExceptions. Added a test to verify requests to endpoint where the RequestUri is null.